### PR TITLE
WIP: C++ LLVM wrappers for ORCJIT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,9 @@ import PackageDescription
 
 let package = Package(
     name: "LLVM",
+    targets: [
+        Target(name: "LLVM", dependencies: ["LLVMWrappers"]),
+    ],
     dependencies: [
         .Package(url: "https://github.com/harlanhaskins/cllvm.git", majorVersion: 0),
     ]

--- a/Sources/LLVMWrappers/include/LLVMWrappers.h
+++ b/Sources/LLVMWrappers/include/LLVMWrappers.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 void *_Nullable LLVMCreateOrcMCJITReplacement(void *_Nonnull module,
-																							void *_Nonnull targetRef);
+                                              void *_Nonnull targetRef);
 void LLVMLinkInOrcMCJITReplacement(void);
 
 #ifdef __cplusplus

--- a/Sources/LLVMWrappers/include/LLVMWrappers.h
+++ b/Sources/LLVMWrappers/include/LLVMWrappers.h
@@ -1,0 +1,16 @@
+#ifndef LLVMWrappers_h
+#define LLVMWrappers_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *_Nullable LLVMCreateOrcMCJITReplacement(void *_Nonnull module,
+																							void *_Nonnull targetRef);
+void LLVMLinkInOrcMCJITReplacement(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LLVMWrappers_hpp */

--- a/Sources/LLVMWrappers/src/LLVMWrappers.cpp
+++ b/Sources/LLVMWrappers/src/LLVMWrappers.cpp
@@ -1,0 +1,24 @@
+#define _DEBUG
+#define _GNU_SOURCE
+#define __STDC_CONSTANT_MACROS
+#define __STDC_FORMAT_MACROS
+#define __STDC_LIMIT_MACROS
+
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
+#include <llvm/ExecutionEngine/OrcMCJITReplacement.h>
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include <llvm/Target/TargetMachine.h>
+
+namespace llvm {
+
+LLVMExecutionEngineRef LLVMCreateOrcMCJITReplacement(LLVMModuleRef module, LLVMTargetMachineRef targetRef) {
+  auto target = reinterpret_cast<TargetMachine *>(targetRef);
+  EngineBuilder builder(std::unique_ptr<Module>(unwrap(module)));
+  builder.setMCJITMemoryManager(make_unique<SectionMemoryManager>());
+  builder.setTargetOptions(target->Options);
+  builder.setUseOrcMCJITReplacement(true);
+  return wrap(builder.create());
+}
+
+}


### PR DESCRIPTION
This won't work for a while, not until SwiftPM gets proper support for C++ dependencies.