### PR TITLE
Guarded imports with a NO_SWIFTPM macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ build.
 Once you do that, you can add LLVMSwift as a dependency for your own Swift
 compiler projects!
 
+### Installation without Swift Package Manager
+
+We really recommend using SwiftPM with LLVMSwift, but if your project is
+structured in such a way that makes using SwiftPM impractical or impossible,
+you can still use LLVMSwift by passing the -DNO_SWIFTPM to swift when
+compiling.
+
+- Xcode:
+  - Add this repository as a git submodule
+  - Add the files in `Sources/` to your Xcode project.
+  - Under `Other Swift Flags`, add `-DNO_SWIFTPM`.
+  - Under `Library Search Paths` add the output of `llvm-config --libdir`
+  - Under `Header Search Paths` add the output of `llvm-config --includedir`
+  - Under `Link Target with Libraries` drag in
+    `/path/to/your/llvm/include/libLLVM.dylib`
+
 This project is used by [Trill](https://github.com/harlanhaskins/trill) for
 all its code generation.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ compiler projects!
 
 We really recommend using SwiftPM with LLVMSwift, but if your project is
 structured in such a way that makes using SwiftPM impractical or impossible,
-you can still use LLVMSwift by passing the -DNO_SWIFTPM to swift when
+you can still use LLVMSwift by passing the `-DNO_SWIFTPM` to swift when
 compiling.
 
 - Xcode:
@@ -72,7 +72,7 @@ compiling.
   - Under `Library Search Paths` add the output of `llvm-config --libdir`
   - Under `Header Search Paths` add the output of `llvm-config --includedir`
   - Under `Link Target with Libraries` drag in
-    `/path/to/your/llvm/include/libLLVM.dylib`
+    `/path/to/your/llvm/lib/libLLVM.dylib`
 
 This project is used by [Trill](https://github.com/harlanhaskins/trill) for
 all its code generation.

--- a/Sources/LLVM/Alias.swift
+++ b/Sources/LLVM/Alias.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// An `Alias` represents a global alias in an LLVM module - a new symbol and
 /// corresponding metadata for an existing position

--- a/Sources/LLVM/ArrayType.swift
+++ b/Sources/LLVM/ArrayType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `ArrayType` is a very simple derived type that arranges elements
 /// sequentially in memory. `ArrayType` requires a size (number of elements) and

--- a/Sources/LLVM/BasicBlock.swift
+++ b/Sources/LLVM/BasicBlock.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A `BasicBlock` represents a basic block in an LLVM IR program.  A basic
 /// block contains a sequence of instructions, a pointer to its parent block and

--- a/Sources/LLVM/FloatType.swift
+++ b/Sources/LLVM/FloatType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `FloatType` enumerates representations of a floating value of a particular
 /// bit width and semantics.

--- a/Sources/LLVM/Function.swift
+++ b/Sources/LLVM/Function.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// Enumerates the calling conventions supported by LLVM.
 ///

--- a/Sources/LLVM/FunctionType.swift
+++ b/Sources/LLVM/FunctionType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `FunctionType` represents a function's type signature.  It consists of a
 /// return type and a list of formal parameter types. The return type of a

--- a/Sources/LLVM/Global.swift
+++ b/Sources/LLVM/Global.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A `Global` represents a region of memory allocated at compile time instead
 /// of at runtime.  A global variable must either have an initializer, or make

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// Species the behavior that should occur on overflow during mathematical
 /// operations.

--- a/Sources/LLVM/IRGlobal.swift
+++ b/Sources/LLVM/IRGlobal.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// An `IRGlobal` is a value, alias, or function that exists at the top level of
 /// an LLVM module.

--- a/Sources/LLVM/IRType.swift
+++ b/Sources/LLVM/IRType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// An `IRType` is a type that is capable of lowering itself to an `LLVMTypeRef`
 /// object for use with LLVM's C API.

--- a/Sources/LLVM/IRValue+Kinds.swift
+++ b/Sources/LLVM/IRValue+Kinds.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 // Automatically generated from the macros in llvm/Core.h
 

--- a/Sources/LLVM/IRValue.swift
+++ b/Sources/LLVM/IRValue.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// An `IRValue` is a type that is capable of lowering itself to an
 /// `LLVMValueRef` object for use with LLVM's C API.

--- a/Sources/LLVM/Initialization.swift
+++ b/Sources/LLVM/Initialization.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// Lazy static initializer that calls LLVM initialization functions only once.
 let llvmInitializer: Void = {

--- a/Sources/LLVM/Instruction.swift
+++ b/Sources/LLVM/Instruction.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// An `Instruction` represents an instruction residing in a basic block.
 public struct Instruction: IRValue {

--- a/Sources/LLVM/IntType.swift
+++ b/Sources/LLVM/IntType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// The `IntType` represents an integral value of a specified bit width.
 ///

--- a/Sources/LLVM/JIT.swift
+++ b/Sources/LLVM/JIT.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// JITError represents the different kinds of errors the JIT compiler can
 /// throw.

--- a/Sources/LLVM/LabelType.swift
+++ b/Sources/LLVM/LabelType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `LabelType` represents code labels.
 public struct LabelType: IRType {

--- a/Sources/LLVM/Linkage.swift
+++ b/Sources/LLVM/Linkage.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `Visibility` enumerates available visibility styles.
 public enum Visibility {

--- a/Sources/LLVM/MemoryBuffer.swift
+++ b/Sources/LLVM/MemoryBuffer.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// Enumerates the possible failures that can be thrown initializing
 /// a MemoryBuffer.

--- a/Sources/LLVM/MetadataType.swift
+++ b/Sources/LLVM/MetadataType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// The `MetadataType` type represents embedded metadata. No derived types may
 /// be created from metadata except for function arguments.

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A `Context` represents execution states for the core LLVM IR system.
 public class Context {

--- a/Sources/LLVM/OpCode.swift
+++ b/Sources/LLVM/OpCode.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// Enumerates the opcodes of instructions available in the LLVM IR language.
 ///

--- a/Sources/LLVM/PassManager.swift
+++ b/Sources/LLVM/PassManager.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A subset of supported LLVM IR optimizer passes.
 public enum FunctionPass {

--- a/Sources/LLVM/PhiNode.swift
+++ b/Sources/LLVM/PhiNode.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A `PhiNode` object represents a PHI node.
 ///

--- a/Sources/LLVM/PointerType.swift
+++ b/Sources/LLVM/PointerType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `PointerType` is used to specify memory locations. Pointers are commonly
 /// used to reference objects in memory.

--- a/Sources/LLVM/StructType.swift
+++ b/Sources/LLVM/StructType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `StructType` is used to represent a collection of data members together in
 /// memory. The elements of a structure may be any type that has a size.

--- a/Sources/LLVM/Switch.swift
+++ b/Sources/LLVM/Switch.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A `Switch` represents a `switch` instruction.  A `switch` instruction
 /// defines a jump table of values and destination basic blocks to pass the flow

--- a/Sources/LLVM/TargetData.swift
+++ b/Sources/LLVM/TargetData.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A `TargetData` encapsulates information about the data requirements of a
 /// particular target architecture and can be used to retrieve information about

--- a/Sources/LLVM/TargetMachine.swift
+++ b/Sources/LLVM/TargetMachine.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// The supported types of files codegen can produce.
 public enum CodegenFileType {

--- a/Sources/LLVM/TokenType.swift
+++ b/Sources/LLVM/TokenType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `TokenType` is used when a value is associated with an instruction but all
 /// uses of the value must not attempt to introspect or obscure it. As such, it

--- a/Sources/LLVM/Use.swift
+++ b/Sources/LLVM/Use.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `Use` represents an iterator over the uses and users of a particular value
 /// in an LLVM program.

--- a/Sources/LLVM/VectorType.swift
+++ b/Sources/LLVM/VectorType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// A `VectorType` is a simple derived type that represents a vector of
 /// elements. `VectorType`s are used when multiple primitive data are operated

--- a/Sources/LLVM/VoidType.swift
+++ b/Sources/LLVM/VoidType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// The `Void` type represents any value and has no size.
 public struct VoidType: IRType {

--- a/Sources/LLVM/X86MMXType.swift
+++ b/Sources/LLVM/X86MMXType.swift
@@ -1,4 +1,6 @@
+#if !NO_SWIFTPM
 import cllvm
+#endif
 
 /// `X86MMXType` represents a value held in an MMX register on an x86 machine.
 ///


### PR DESCRIPTION
This would allow clients to include LLVMSwift source files in a project without needing SwiftPM. Useful while SwiftPM is completely separate from Xcode.