### PR TITLE
Use explicit version number for pkgconfig

### DIFF
--- a/utils/make-pkgconfig.swift
+++ b/utils/make-pkgconfig.swift
@@ -58,7 +58,7 @@ func makeFile() throws {
   let cllvmPath = pkgConfigDir.appendingPathComponent("cllvm.pc")
 
   /// Ensure we have llvm-config in the PATH
-  guard let llvmConfig = which("llvm-config") else {
+  guard let llvmConfig = which("llvm-config-3.9") else {
     throw "Failed to find llvm-config. Ensure llvm-config is installed and " +
           "in your PATH"
   }


### PR DESCRIPTION
I believe that the `llvm-config` executable is typicaclly a link to the specific version, so it should be a no-op for the most part. However, I was having trouble building this on Ubuntu 16.04 since I only have the `llvm-config-3.9` executable. This small change fixed it.

I cannot confirm this for macOS though.

Thanks