### PR TITLE
Fixed BasicBlock.parent and added IRBuilder.currentFunction

### DIFF
--- a/Sources/LLVM/BasicBlock.swift
+++ b/Sources/LLVM/BasicBlock.swift
@@ -40,10 +40,10 @@ public struct BasicBlock: IRValue {
     return Instruction(llvm: val)
   }
 
-  /// Returns the parent of this basic block, if it exists.
-  public func parent() -> BasicBlock? {
-    guard let blockRef = LLVMGetBasicBlockParent(llvm) else { return nil }
-    return BasicBlock(llvm: blockRef)
+  /// Returns the parent function of this basic block, if it exists.
+  public var parent: Function? {
+    guard let functionRef = LLVMGetBasicBlockParent(llvm) else { return nil }
+    return Function(llvm: functionRef)
   }
 
   /// Returns the basic block following this basic block, if it exists.

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -400,6 +400,11 @@ public class IRBuilder {
     return BasicBlock(llvm: blockRef)
   }
 
+  /// Gets the function this builder is building into.
+  public var currentFunction: Function? {
+    return insertBlock?.parent
+  }
+
   /// Inserts the given instruction into the IR Builder.
   ///
   /// - parameter inst: The instruction to insert.


### PR DESCRIPTION
Gives a canonical way to retrieve the function the builder is currently working in