### PR TITLE
Remove de-initializers that `dispose` of LLVM objects

### DIFF
--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1706,7 +1706,8 @@ public class IRBuilder {
     return Alias(llvm: LLVMAddAlias(module.llvm, type.asLLVM(), aliasee.asLLVM(), name))
   }
 
-  deinit {
-    LLVMDisposeBuilder(llvm)
-  }
+  // FIXME: Re-introduce this when disposal becomes safe.
+//  deinit {
+//    LLVMDisposeBuilder(llvm)
+//  }
 }

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -193,9 +193,10 @@ public final class Module: CustomStringConvertible {
     return String(cString: cStr)
   }
 
-  deinit {
-    LLVMDisposeModule(llvm)
-  }
+  // FIXME: Re-introduce this when disposal becomes safe.
+//  deinit {
+//    LLVMDisposeModule(llvm)
+//  }
 }
 
 extension Bool {

--- a/Sources/LLVM/TargetMachine.swift
+++ b/Sources/LLVM/TargetMachine.swift
@@ -212,7 +212,8 @@ public class TargetMachine {
     return MemoryBuffer(llvm: llvm)
   }
 
-  deinit {
-    LLVMDisposeTargetMachine(llvm)
-  }
+  // FIXME: Re-introduce this when disposal becomes safe.
+//  deinit {
+//    LLVMDisposeTargetMachine(llvm)
+//  }
 }


### PR DESCRIPTION
I'm leaving the one behind in the memory buffer implementation unless you mention that that one causes crashes too.