### PR TITLE
Revert "Remove de-initializers that `dispose` of LLVM objects"

### DIFF
--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1706,8 +1706,7 @@ public class IRBuilder {
     return Alias(llvm: LLVMAddAlias(module.llvm, type.asLLVM(), aliasee.asLLVM(), name))
   }
 
-  // FIXME: Re-introduce this when disposal becomes safe.
-//  deinit {
-//    LLVMDisposeBuilder(llvm)
-//  }
+  deinit {
+    LLVMDisposeBuilder(llvm)
+  }
 }

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -193,10 +193,9 @@ public final class Module: CustomStringConvertible {
     return String(cString: cStr)
   }
 
-  // FIXME: Re-introduce this when disposal becomes safe.
-//  deinit {
-//    LLVMDisposeModule(llvm)
-//  }
+  deinit {
+    LLVMDisposeModule(llvm)
+  }
 }
 
 extension Bool {

--- a/Sources/LLVM/TargetMachine.swift
+++ b/Sources/LLVM/TargetMachine.swift
@@ -212,8 +212,7 @@ public class TargetMachine {
     return MemoryBuffer(llvm: llvm)
   }
 
-  // FIXME: Re-introduce this when disposal becomes safe.
-//  deinit {
-//    LLVMDisposeTargetMachine(llvm)
-//  }
+  deinit {
+    LLVMDisposeTargetMachine(llvm)
+  }
 }


### PR DESCRIPTION
This reverts commit e5c6e6c8a0de171a02cae6e66794c69efa8a963c.  Disposal is not the problem, dangling references to removed Basic Blocks is the issue.  