### PR TITLE
Run static constructors/destructors on init/deinit

### DIFF
--- a/Sources/LLVM/JIT.swift
+++ b/Sources/LLVM/JIT.swift
@@ -51,6 +51,7 @@ public final class JIT {
       throw JITError.couldNotInitialize("JIT was NULL")
     }
     self.llvm = _jit
+    LLVMRunStaticConstructors(self.llvm)
   }
 
   /// Runs the specified function with the provided arguments by compiling
@@ -120,6 +121,10 @@ public final class JIT {
                                        UInt32(buf.count),
                                        buf.baseAddress, nil))
     }
+  }
+
+  deinit {
+    LLVMRunStaticDestructors(self.llvm)
   }
 }
 


### PR DESCRIPTION
The JIT needs to be instructed to perform these actions.  Because I can't think of a reason not to run this code, execute the constructors in `init` and the destructors in `deinit`.