### PR TITLE
Update PHI node example in README to use more idiomatic structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,6 @@ let function = builder.addFunction(
 let entryBB = function.appendBasicBlock(named: "entry")
 builder.positionAtEnd(of: entryBB)
 
-// allocate space for a local value
-let local = builder.buildAlloca(type: FloatType.double, name: "local")
-
 // Compare to the condition
 let test = builder.buildICmp(function.parameters[0], IntType.int1.zero(), .notEqual)
 
@@ -120,7 +117,6 @@ builder.buildCondBr(condition: test, then: thenBB, else: elseBB)
 builder.positionAtEnd(of: thenBB)
 // local = 1/89, the fibonacci series (sort of)
 let thenVal = FloatType.double.constant(1/89)
-builder.buildStore(thenVal, to: local)
 // Branch to the merge block
 builder.buildBr(mergeBB)
 
@@ -128,7 +124,6 @@ builder.buildBr(mergeBB)
 builder.positionAtEnd(of: elseBB)
 // local = 1/109, the fibonacci series (sort of) backwards
 let elseVal = FloatType.double.constant(1/109)
-builder.buildStore(elseVal, to: local)
 // Branch to the merge block
 builder.buildBr(mergeBB)
 
@@ -147,16 +142,13 @@ This program generates the following IR:
 ```llvm
 define double @calculateFibs(i1) {
 entry:
-  %local = alloca double
   %1 = icmp ne i1 %0, false
   br i1 %1, label %then, label %else
 
 then:                                             ; preds = %entry
-  store double 0x3F8702E05C0B8170, double* %local
   br label %merge
 
 else:                                             ; preds = %entry
-  store double 0x3F82C9FB4D812CA0, double* %local
   br label %merge
 
 merge:                                            ; preds = %else, %then


### PR DESCRIPTION
When using LLVM's PHI nodes, creating a local variable to store the result in each preceding branch defeats the purpose of using PHI nodes in the first place (or, at the very least, obscures their purpose). With the use of `local` in the example originally, the program could be trivially rewritten as:

```
define double @calculateFibs(i1) {
entry:
  %local = alloca double
  %1 = icmp ne i1 %0, false
  br i1 %1, label %then, label %else

then:                                             ; preds = %entry
  store double 0x3F8702E05C0B8170, double* %local
  br label %merge

else:                                             ; preds = %entry
  store double 0x3F82C9FB4D812CA0, double* %local
  br label %merge

merge:                                            ; preds = %else, %then
  %retVal = load double, double* %local
  ret double %retVal
}
```
which sidesteps the need for a PHI node at all. I've rewritten the example to remove the unused `local` variable and to make the power of PHI nodes clearer.