### PR TITLE
Wrap LLVM Intrinsics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Package.resolved
 Package.pins
 /*.xcodeproj
 /build
+/Sources/LLVMIntrinsics/IntrinsicsDef.swift

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - brew update
     - brew install llvm
     - sudo swift utils/make-pkgconfig.swift
+    - sudo swift utils/intrinsics-gen.swift Tests/Resources/Intrinsics.td
     script:
     - swift test -Xlinker -w
   - os: linux
@@ -37,6 +38,7 @@ matrix:
     - tar xzf swift-4.2-RELEASE-ubuntu14.04.tar.gz
     - export PATH=${PWD}/swift-4.2-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
     - sudo ./swift-4.2-RELEASE-ubuntu14.04/usr/bin/swift utils/make-pkgconfig.swift
+    - sudo ./swift-4.2-RELEASE-ubuntu14.04/usr/bin/swift utils/intrinsics-gen.swift Tests/Resources/Intrinsics.td
     script:
     - swift test
 notifications:

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,9 @@ let package = Package(
     .library(
       name: "LLVM",
       targets: ["LLVM"]),
+    .library(
+      name: "LLVMIntrinsics",
+      targets: ["LLVMIntrinsics"]),
   ],
   dependencies: [
     .package(url: "https://github.com/llvm-swift/FileCheck.git", from: "0.0.3"),
@@ -25,5 +28,11 @@ let package = Package(
     .testTarget(
       name: "LLVMTests",
       dependencies: ["LLVM", "FileCheck"]),
+    .target(
+      name: "LLVMIntrinsics",
+      dependencies: ["LLVM"]),
+    .testTarget(
+      name: "LLVMIntrinsicsTests",
+      dependencies: ["LLVMIntrinsics", "LLVM", "FileCheck"]),
   ]
 )

--- a/Sources/LLVM/Intrinsics.swift
+++ b/Sources/LLVM/Intrinsics.swift
@@ -1,0 +1,216 @@
+#if !NO_SWIFTPM
+import cllvm
+#endif
+
+/// The `LLVMIntrinsic` protocol represents types that act as selectors for
+/// intrinsic functions.
+///
+/// LLVM supports the notion of an “intrinsic function”. These functions have
+/// well known names and semantics and are required to follow certain
+/// restrictions. Overall, these intrinsics represent an extension mechanism for
+/// the LLVM language that does not require changing all of the transformations
+/// in LLVM when adding to the language.
+///
+/// Intrinsic function names all start with an "llvm." prefix. This prefix is
+/// reserved in LLVM for intrinsic names; thus, function names may not begin
+/// with this prefix. Intrinsic functions must always be external functions:
+/// you cannot define the body of intrinsic functions. Intrinsic functions may
+/// only be used in call or invoke instructions: it is illegal to take the
+/// address of an intrinsic function.
+public protocol LLVMIntrinsic {
+  var signature: FunctionType { get }
+  var llvmSelector: String { get }
+}
+
+/// The `LLVMOverloadedIntrinsic` protocol represents types that act as
+/// selectors for a family of overloaded intrinsic functions.
+///
+/// Some intrinsic functions can be overloaded, i.e., the intrinsic represents a
+/// family of functions that perform the same operation but on different data
+/// types. Because LLVM can represent over 8 million different integer types,
+/// overloading is used commonly to allow an intrinsic function to operate on
+/// any integer type. One or more of the argument types or the result type can
+/// be overloaded to accept any integer type. Argument types may also be defined
+/// as exactly matching a previous argument’s type or the result type. This
+/// allows an intrinsic function which accepts multiple arguments, but needs all
+/// of them to be of the same type, to only be overloaded with respect to a
+/// single argument or the result.
+///
+/// Overloaded intrinsics will have the names of its overloaded argument types
+/// encoded into its function name, each preceded by a period. Only those types
+/// which are overloaded result in a name suffix. Arguments whose type is
+/// matched against another type do not. For example, the llvm.ctpop function
+/// can take an integer of any width and returns an integer of exactly the same
+/// integer width. This leads to a family of functions such as
+/// `i8 @llvm.ctpop.i8(i8 %val)` and i29 `@llvm.ctpop.i29(i29 %val)`. Only one
+/// type, the return type, is overloaded, and only one type suffix is required.
+/// Because the argument’s type is matched against the return type, it does not
+/// require its own name suffix.
+public protocol LLVMOverloadedIntrinsic: LLVMIntrinsic {
+  static var overloadSet: [LLVMIntrinsic] { get }
+}
+
+extension IRBuilder {
+  /// Builds a call to an intrinsic function.
+  ///
+  /// - note: In debug builds this function type checks its arguments to ensure
+  ///         calls are well-formed.  In release builds no such checking will
+  ///         occur and all calls to intrinsics with mismatched arguments will
+  ///         result in undefined behavior.
+  ///
+  /// - Parameters:
+  ///   - intr: The selector for the intrinsic to be invoked.
+  ///   - returnType: A suggested return type for overloaded intrinsics.  By
+  ///     default, the framework will infer a type and attempt to match the
+  ///     right intrinsic function.
+  ///   - args: The arguments to the intrinsic function.
+  /// - Returns: A value representing the result of calling the intrinsic
+  ///   function.
+  public func buildIntrinsicCall<I: LLVMIntrinsic>(to intr: I, returnType: IRType? = nil, args: IRValue...) -> IRValue {
+    assert(typeCheckArguments(to: intr, args: args))
+
+    return self.buildCall(self.buildIntrinsic(self.resolveIntrinsic(intr, args, returnType)), args: args)
+  }
+
+  
+  /// Builds a call to one of a family of overloaded intrinsic functions.
+  ///
+  /// - note: The type of the arguments ultimately determines the selector for
+  ///         the intrinsic that is called.  Failure of the arguments to
+  ///         correspond to any of the overloads is a fatal condition.
+  ///
+  /// - Parameters:
+  ///   - intr: The selector for the overloaded intrinsic to be resolved and
+  ///     invoked.
+  ///   - returnType: A suggested return type for overloaded intrinsics.  By
+  ///     default, the framework will infer a type and attempt to match the
+  ///     right intrinsic function.
+  ///   - args: The arguments to the intrinsic function.
+  /// - Returns: A value representing the result of calling the intrinsic
+  ///   function.
+  public func buildIntrinsicCall<I: LLVMOverloadedIntrinsic>(to intr: I.Type, returnType: IRType? = nil, args: IRValue...) -> IRValue  {
+    guard let intr = resolveOverloadedArguments(to: intr, args: args) else {
+      fatalError("Unable to resolve overload among \(I.overloadSet.map{$0.llvmSelector})")
+    }
+    return self.buildCall(self.buildIntrinsic(self.resolveIntrinsic(intr, args, returnType)), args: args)
+  }
+
+  private func resolveIntrinsic(_ i: LLVMIntrinsic, _ args: [IRValue], _ returnTy: IRType?) -> LLVMIntrinsic {
+    let fnArgTypes = i.signature.argTypes
+
+    func typeNameForType(_ type: IRType) -> String {
+      if let iTy = type as? IntType {
+        return "i\(iTy.width)"
+      } else if let fTy = type as? FloatType {
+        switch fTy.kind {
+        case .half:
+          return "f16"
+        case .float:
+          return "f32"
+        case .double:
+          return "f64"
+        case .x86FP80:
+          return "f80"
+        case .fp128:
+          return "f128"
+        case .ppcFP128:
+          return "ppcf128"
+        }
+      } else if let pTy = type as? PointerType {
+        return "p0" + typeNameForType(pTy.pointee)
+      } else if let vTy = type as? VectorType {
+        return "v\(vTy.count)" + typeNameForType(vTy.elementType)
+      }
+      fatalError()
+    }
+
+    var argTypes = [IRType]()
+    var sigName = i.llvmSelector
+    for t in zip(fnArgTypes, args) {
+      guard t.0 is IntrinsicSubstitutionMarker else {
+        argTypes.append(t.0)
+        continue
+      }
+      argTypes.append(t.1.type)
+      sigName += "." + typeNameForType(t.1.type)
+    }
+
+    let retTy: IRType
+    if i.signature.returnType is IntrinsicSubstitutionMarker {
+      // HACK: Sometimes the return type is generic.  This is nice for people that
+      // are writing textual IR and know their types ahead of time, but we have
+      // no such luck.  All of the intrinsics seems to be predicated on the idea
+      // that the first substitution we perform matches the desired return type.
+      guard let potentialRetTy = returnTy ?? argTypes.first else {
+        fatalError("Unable to disambiguate return type for overloaded intrinsic \(i.llvmSelector); provide one explicitly.")
+      }
+      retTy = potentialRetTy
+    } else {
+      retTy = i.signature.returnType
+    }
+    return ResolvedIntrinsic(signature: FunctionType(argTypes: argTypes, returnType: retTy), llvmSelector: sigName)
+  }
+
+  private func buildIntrinsic(_ i: LLVMIntrinsic) -> Function  {
+    if let f = self.module.function(named: i.llvmSelector) {
+      return f
+    }
+    var f = self.addFunction(i.llvmSelector, type: i.signature)
+    f.linkage = .external
+    return f
+  }
+
+  private func typeCheckArguments<I: LLVMIntrinsic>(to fn: I, args: [IRValue]) -> Bool {
+    let fnArgTypes = fn.signature.argTypes
+    guard fnArgTypes.count == args.count else { return false }
+    for t in zip(fnArgTypes, args) {
+      // <SUB> => T
+      if t.0 is IntrinsicSubstitutionMarker {
+        continue
+      } else if let vecTy = t.0 as? VectorType, vecTy.elementType is IntrinsicSubstitutionMarker  {
+        // Vector<n, <SUB>> => Vector<n, T>
+        guard t.1 is VectorType else {
+          return false
+        }
+        continue
+      } else if let vecTy = t.0 as? VectorType, vecTy.count == -1 {
+        // Vector<-1, T> => Vector<n, T>
+        guard let vecTy2 = t.1 as? VectorType, vecTy.elementType.asLLVM() == vecTy2.elementType.asLLVM() else {
+          return false
+        }
+        continue
+      }
+
+      // Fall back to pointer equality
+      guard t.0.asLLVM() == t.1.type.asLLVM() else { return false }
+    }
+    return true
+  }
+
+  private func resolveOverloadedArguments<I: LLVMOverloadedIntrinsic>(to fns: I.Type, args: [IRValue]) -> LLVMIntrinsic? {
+    return fns.overloadSet.filter({ (fn) -> Bool in
+      let fnArgTypes = fn.signature.argTypes
+      guard fnArgTypes.count == args.count else { return false }
+      for t in zip(fnArgTypes, args) {
+        guard t.0.asLLVM() == t.1.type.asLLVM() else { return false }
+      }
+      return true
+    }).first
+  }
+}
+
+// A marker type generated by the 'intrinsics-gen' tool to indicate that a
+// substitution should be performed on an argument.  They cannot be reified into
+// an LLVM Type and will trap if an attempt is made to do so.
+public struct IntrinsicSubstitutionMarker: IRType {
+  public init() {}
+  public func asLLVM() -> LLVMTypeRef {
+    fatalError("Unhandled substitution marker in type")
+  }
+}
+
+/// A marker intrinsic for the candidate selected during overload resolution.
+private struct ResolvedIntrinsic: LLVMIntrinsic {
+  let signature: FunctionType
+  let llvmSelector: String
+}

--- a/Sources/LLVMIntrinsics/IntrinsicsDef.swift
+++ b/Sources/LLVMIntrinsics/IntrinsicsDef.swift
@@ -1,0 +1,10 @@
+/*! THIS FILE INTENTIONALLY LEFT BLANK !*/
+///
+/// LLVMSwift does not ship with an intrinsics API by default.  To enable it,
+/// you must run
+///
+///     $ swift ./utils/intrinsics-gen.swift /Path/To/Intrinsics.td
+///
+/// To run the tests for LLVMSwiftIntrinsics, you should at least run
+///
+///     $ swift ./utils/intrinsics-gen.swift Tests/Resources/Intrinsics.td

--- a/Tests/LLVMIntrinsicsTests/IRIntrinsicSpec.swift
+++ b/Tests/LLVMIntrinsicsTests/IRIntrinsicSpec.swift
@@ -1,0 +1,156 @@
+import LLVM
+import LLVMIntrinsics
+import XCTest
+import Foundation
+import FileCheck
+
+class IRIntrinsicSpec : XCTestCase {
+  func testIRIntrinsics() {
+    XCTAssert(fileCheckOutput(of: .stderr, withPrefixes: ["IRINTRINSIC"]) {
+      // IRINTRINSIC: ; ModuleID = '[[ModuleName:IRIntrinsicTest]]'
+      // IRINTRINSIC-NEXT: source_filename = "[[ModuleName]]"
+      let module = Module(name: "IRIntrinsicTest")
+      let builder = IRBuilder(module: module)
+      // IRINTRINSIC: define i32 @readOneArg(i32, ...) {
+      let main = builder.addFunction("readOneArg",
+                                     type: FunctionType(argTypes: [IntType.int32],
+                                                        returnType: IntType.int32,
+                                                        isVarArg: true))
+      // IRINTRINSIC-NEXT: entry:
+      let entry = main.appendBasicBlock(named: "entry")
+      builder.positionAtEnd(of: entry)
+
+      // IRINTRINSIC-NEXT: [[VA_BUF:%[0-9]+]] = alloca i8*
+      let ap = builder.buildAlloca(type: PointerType(pointee: IntType.int8))
+      // IRINTRINSIC-NEXT: [[CAST_VA_BUF:%[0-9]+]] = bitcast i8** [[VA_BUF]] to i8*
+      let ap2 = builder.buildBitCast(ap, type: PointerType(pointee: IntType.int8))
+
+      // IRINTRINSIC-NEXT: call void @llvm.va_start(i8* [[CAST_VA_BUF]])
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.llvm_va_start, args: ap2)
+
+      // IRINTRINSIC-NEXT: [[RET_VAL:%[0-9]+]] = va_arg i8** [[VA_BUF]], i32
+      let tmp = builder.buildVAArg(ap, type: IntType.int32)
+
+      // IRINTRINSIC-NEXT: [[VA_COPY_BUF:%[0-9]+]] = alloca i8*
+      let aq = builder.buildAlloca(type: PointerType(pointee: IntType.int8))
+      // IRINTRINSIC-NEXT: [[CAST_VA_COPY_BUF:%[0-9]+]] = bitcast i8** [[VA_COPY_BUF]] to i8*
+      let aq2 = builder.buildBitCast(aq, type: PointerType(pointee: IntType.int8))
+
+      // IRINTRINSIC-NEXT: call void @llvm.va_copy(i8* [[CAST_VA_BUF]], i8* [[CAST_VA_COPY_BUF]])
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.llvm_va_copy, args: ap2, aq2)
+      // IRINTRINSIC-NEXT: call void @llvm.va_end(i8* [[CAST_VA_COPY_BUF]])
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.llvm_va_end, args: aq2)
+
+      // IRINTRINSIC-NEXT: call void @llvm.va_end(i8* [[CAST_VA_BUF]])
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.llvm_va_end, args: ap2)
+
+      // IRINTRINSIC-NEXT: i32 [[RET_VAL]]
+      builder.buildRet(tmp)
+      // IRINTRINSIC-NEXT: }
+      module.dump()
+
+      // IRINTRINSIC: ; Function Attrs: nounwind
+      // IRINTRINSIC-NEXT: declare void @llvm.va_start(i8*) #0
+
+      // IRINTRINSIC: ; Function Attrs: nounwind
+      // IRINTRINSIC-NEXT: declare void @llvm.va_copy(i8*, i8*) #0
+
+      // IRINTRINSIC: ; Function Attrs: nounwind
+      // IRINTRINSIC-NEXT: declare void @llvm.va_end(i8*) #0
+    })
+
+    XCTAssert(fileCheckOutput(of: .stderr, withPrefixes: ["VIRTUALOVERLOAD-IRINTRINSIC"]) {
+      // VIRTUALOVERLOAD-IRINTRINSIC: ; ModuleID = '[[ModuleName:IRIntrinsicTest]]'
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: source_filename = "[[ModuleName]]"
+      let module = Module(name: "IRIntrinsicTest")
+      let builder = IRBuilder(module: module)
+      // VIRTUALOVERLOAD-IRINTRINSIC: define i32 @main() {
+      let main = builder.addFunction("main",
+                                     type: FunctionType(argTypes: [],
+                                                        returnType: IntType.int32))
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: entry:
+      let entry = main.appendBasicBlock(named: "entry")
+      builder.positionAtEnd(of: entry)
+
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: [[VAR_PTR:%[0-9]+]] = alloca i32
+      let variable = builder.buildAlloca(type: IntType.int32)
+
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: store i32 1, i32* [[VAR_PTR]]
+      builder.buildStore(IntType.int32.constant(1), to: variable)
+
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: [[COPY_PTR:%[0-9]+]] = call i32* @llvm.ssa_copy.p0i32(i32* %0)
+      let cpyVar = builder.buildIntrinsicCall(to: GlobalIntrinsics.llvm_ssa_copy, args: variable)
+
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: [[LOAD_VAR:%[0-9]+]] = load i32, i32* [[COPY_PTR]]
+      let loadVar = builder.buildLoad(cpyVar)
+
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT:  ret i32 [[LOAD_VAR]]
+      builder.buildRet(loadVar)
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT:  }
+      module.dump()
+    })
+
+    XCTAssert(fileCheckOutput(of: .stderr, withPrefixes: ["INTRINSIC-FAMILY-RESOLVE"]) {
+      // INTRINSIC-FAMILY-RESOLVE: ; ModuleID = '[[ModuleName:IRIntrinsicTest]]'
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: source_filename = "[[ModuleName]]"
+      let module = Module(name: "IRIntrinsicTest")
+      let builder = IRBuilder(module: module)
+      // INTRINSIC-FAMILY-RESOLVE: define i32 @main() {
+      let main = builder.addFunction("main",
+                                     type: FunctionType(argTypes: [],
+                                                        returnType: IntType.int32))
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: entry:
+      let entry = main.appendBasicBlock(named: "entry")
+      builder.positionAtEnd(of: entry)
+
+      let doubleAlloca = builder.buildAlloca(type: FloatType.double)
+      builder.buildStore(FloatType.double.constant(1.0), to: doubleAlloca)
+      let double = builder.buildLoad(doubleAlloca)
+
+      let floatAlloca = builder.buildAlloca(type: FloatType.float)
+      builder.buildStore(FloatType.float.constant(1.0), to: floatAlloca)
+      let float = builder.buildLoad(floatAlloca)
+
+      let halfAlloca = builder.buildAlloca(type: FloatType.half)
+      builder.buildStore(FloatType.half.constant(1.0), to: halfAlloca)
+      let half = builder.buildLoad(halfAlloca)
+
+      // INTRINSIC-FAMILY-RESOLVE: call double @llvm.sin.f64(double
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_sin.self, args: double)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call double @llvm.cos.f64(double
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_cos.self, args: double)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call double @llvm.sqrt.f64(double
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_sqrt.self, args: double)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call double @llvm.log.f64(double
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_log.self, args: double)
+
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call float @llvm.sin.f32(float
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_sin.self, args: float)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call float @llvm.cos.f32(float
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_cos.self, args: float)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call float @llvm.sqrt.f32(float
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_sqrt.self, args: float)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call float @llvm.log.f32(float
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_log.self, args: float)
+
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call half @llvm.sin.f16(half
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_sin.self, args: half)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call half @llvm.cos.f16(half
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_cos.self, args: half)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call half @llvm.sqrt.f16(half
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_sqrt.self, args: half)
+      // INTRINSIC-FAMILY-RESOLVE-NEXT: call half @llvm.log.f16(half
+      _ = builder.buildIntrinsicCall(to: GlobalIntrinsics.int_log.self, args: half)
+
+      builder.buildRet(IntType.int32.zero())
+      module.dump()
+    })
+  }
+
+  #if !os(macOS)
+  static var allTests = testCase([
+    ("testIRIntrinsics", testIRIntrinsics),
+  ])
+  #endif
+}
+

--- a/Tests/Resources/Intrinsics.td
+++ b/Tests/Resources/Intrinsics.td
@@ -1,0 +1,811 @@
+//===- Intrinsics.td - Defines all LLVM intrinsics ---------*- tablegen -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines properties of all LLVM intrinsics.
+//
+//===----------------------------------------------------------------------===//
+
+include "llvm/CodeGen/ValueTypes.td"
+
+//===----------------------------------------------------------------------===//
+//  Properties we keep track of for intrinsics.
+//===----------------------------------------------------------------------===//
+
+class IntrinsicProperty;
+
+// Intr*Mem - Memory properties.  If no property is set, the worst case
+// is assumed (it may read and write any memory it can get access to and it may
+// have other side effects).
+
+// IntrNoMem - The intrinsic does not access memory or have any other side
+// effects.  It may be CSE'd deleted if dead, etc.
+def IntrNoMem : IntrinsicProperty;
+
+// IntrReadMem - This intrinsic only reads from memory. It does not write to
+// memory and has no other side effects. Therefore, it cannot be moved across
+// potentially aliasing stores. However, it can be reordered otherwise and can
+// be deleted if dead.
+def IntrReadMem : IntrinsicProperty;
+
+// IntrWriteMem - This intrinsic only writes to memory, but does not read from
+// memory, and has no other side effects. This means dead stores before calls
+// to this intrinsics may be removed.
+def IntrWriteMem : IntrinsicProperty;
+
+// IntrArgMemOnly - This intrinsic only accesses memory that its pointer-typed
+// argument(s) points to, but may access an unspecified amount. Other than
+// reads from and (possibly volatile) writes to memory, it has no side effects.
+def IntrArgMemOnly : IntrinsicProperty;
+
+// IntrInaccessibleMemOnly -- This intrinsic only accesses memory that is not
+// accessible by the module being compiled. This is a weaker form of IntrNoMem.
+def IntrInaccessibleMemOnly : IntrinsicProperty;
+
+// IntrInaccessibleMemOrArgMemOnly -- This intrinsic only accesses memory that
+// its pointer-typed arguments point to or memory that is not accessible
+// by the module being compiled. This is a weaker form of IntrArgMemOnly.
+def IntrInaccessibleMemOrArgMemOnly : IntrinsicProperty;
+
+// Commutative - This intrinsic is commutative: X op Y == Y op X.
+def Commutative : IntrinsicProperty;
+
+// Throws - This intrinsic can throw.
+def Throws : IntrinsicProperty;
+
+// NoCapture - The specified argument pointer is not captured by the intrinsic.
+class NoCapture<int argNo> : IntrinsicProperty {
+  int ArgNo = argNo;
+}
+
+// Returned - The specified argument is always the return value of the
+// intrinsic.
+class Returned<int argNo> : IntrinsicProperty {
+  int ArgNo = argNo;
+}
+
+// ReadOnly - The specified argument pointer is not written to through the
+// pointer by the intrinsic.
+class ReadOnly<int argNo> : IntrinsicProperty {
+  int ArgNo = argNo;
+}
+
+// WriteOnly - The intrinsic does not read memory through the specified
+// argument pointer.
+class WriteOnly<int argNo> : IntrinsicProperty {
+  int ArgNo = argNo;
+}
+
+// ReadNone - The specified argument pointer is not dereferenced by the
+// intrinsic.
+class ReadNone<int argNo> : IntrinsicProperty {
+  int ArgNo = argNo;
+}
+
+def IntrNoReturn : IntrinsicProperty;
+
+// IntrNoduplicate - Calls to this intrinsic cannot be duplicated.
+// Parallels the noduplicate attribute on LLVM IR functions.
+def IntrNoDuplicate : IntrinsicProperty;
+
+// IntrConvergent - Calls to this intrinsic are convergent and may not be made
+// control-dependent on any additional values.
+// Parallels the convergent attribute on LLVM IR functions.
+def IntrConvergent : IntrinsicProperty;
+
+//===----------------------------------------------------------------------===//
+// Types used by intrinsics.
+//===----------------------------------------------------------------------===//
+
+class LLVMType<ValueType vt> {
+  ValueType VT = vt;
+}
+
+class LLVMQualPointerType<LLVMType elty, int addrspace>
+  : LLVMType<iPTR>{
+  LLVMType ElTy = elty;
+  int AddrSpace = addrspace;
+}
+
+class LLVMPointerType<LLVMType elty>
+  : LLVMQualPointerType<elty, 0>;
+
+class LLVMAnyPointerType<LLVMType elty>
+  : LLVMType<iPTRAny>{
+  LLVMType ElTy = elty;
+}
+
+// Match the type of another intrinsic parameter.  Number is an index into the
+// list of overloaded types for the intrinsic, excluding all the fixed types.
+// The Number value must refer to a previously listed type.  For example:
+//   Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_anyfloat_ty, LLVMMatchType<0>]>
+// has two overloaded types, the 2nd and 3rd arguments.  LLVMMatchType<0>
+// refers to the first overloaded type, which is the 2nd argument.
+class LLVMMatchType<int num>
+  : LLVMType<OtherVT>{
+  int Number = num;
+}
+
+// Match the type of another intrinsic parameter that is expected to be based on
+// an integral type (i.e. either iN or <N x iM>), but change the scalar size to
+// be twice as wide or half as wide as the other type.  This is only useful when
+// the intrinsic is overloaded, so the matched type should be declared as iAny.
+class LLVMExtendedType<int num> : LLVMMatchType<num>;
+class LLVMTruncatedType<int num> : LLVMMatchType<num>;
+class LLVMVectorSameWidth<int num, LLVMType elty>
+  : LLVMMatchType<num> {
+  ValueType ElTy = elty.VT;
+}
+class LLVMPointerTo<int num> : LLVMMatchType<num>;
+class LLVMPointerToElt<int num> : LLVMMatchType<num>;
+class LLVMVectorOfPointersToElt<int num> : LLVMMatchType<num>;
+
+// Match the type of another intrinsic parameter that is expected to be a
+// vector type, but change the element count to be half as many
+class LLVMHalfElementsVectorType<int num> : LLVMMatchType<num>;
+
+def llvm_void_ty       : LLVMType<isVoid>;
+def llvm_any_ty        : LLVMType<Any>;
+def llvm_anyint_ty     : LLVMType<iAny>;
+def llvm_anyfloat_ty   : LLVMType<fAny>;
+def llvm_anyvector_ty  : LLVMType<vAny>;
+def llvm_i1_ty         : LLVMType<i1>;
+def llvm_i8_ty         : LLVMType<i8>;
+def llvm_i16_ty        : LLVMType<i16>;
+def llvm_i32_ty        : LLVMType<i32>;
+def llvm_i64_ty        : LLVMType<i64>;
+def llvm_half_ty       : LLVMType<f16>;
+def llvm_float_ty      : LLVMType<f32>;
+def llvm_double_ty     : LLVMType<f64>;
+def llvm_f80_ty        : LLVMType<f80>;
+def llvm_f128_ty       : LLVMType<f128>;
+def llvm_ppcf128_ty    : LLVMType<ppcf128>;
+def llvm_ptr_ty        : LLVMPointerType<llvm_i8_ty>;             // i8*
+def llvm_ptrptr_ty     : LLVMPointerType<llvm_ptr_ty>;            // i8**
+def llvm_anyptr_ty     : LLVMAnyPointerType<llvm_i8_ty>;          // (space)i8*
+def llvm_empty_ty      : LLVMType<OtherVT>;                       // { }
+def llvm_descriptor_ty : LLVMPointerType<llvm_empty_ty>;          // { }*
+def llvm_metadata_ty   : LLVMType<MetadataVT>;                    // !{...}
+def llvm_token_ty      : LLVMType<token>;                         // token
+
+def llvm_x86mmx_ty     : LLVMType<x86mmx>;
+def llvm_ptrx86mmx_ty  : LLVMPointerType<llvm_x86mmx_ty>;         // <1 x i64>*
+
+def llvm_v2i1_ty       : LLVMType<v2i1>;     //   2 x i1
+def llvm_v4i1_ty       : LLVMType<v4i1>;     //   4 x i1
+def llvm_v8i1_ty       : LLVMType<v8i1>;     //   8 x i1
+def llvm_v16i1_ty      : LLVMType<v16i1>;    //  16 x i1
+def llvm_v32i1_ty      : LLVMType<v32i1>;    //  32 x i1
+def llvm_v64i1_ty      : LLVMType<v64i1>;    //  64 x i1
+def llvm_v512i1_ty     : LLVMType<v512i1>;   // 512 x i1
+def llvm_v1024i1_ty    : LLVMType<v1024i1>;  //1024 x i1
+
+def llvm_v1i8_ty       : LLVMType<v1i8>;     //  1 x i8
+def llvm_v2i8_ty       : LLVMType<v2i8>;     //  2 x i8
+def llvm_v4i8_ty       : LLVMType<v4i8>;     //  4 x i8
+def llvm_v8i8_ty       : LLVMType<v8i8>;     //  8 x i8
+def llvm_v16i8_ty      : LLVMType<v16i8>;    // 16 x i8
+def llvm_v32i8_ty      : LLVMType<v32i8>;    // 32 x i8
+def llvm_v64i8_ty      : LLVMType<v64i8>;    // 64 x i8
+def llvm_v128i8_ty     : LLVMType<v128i8>;   //128 x i8
+def llvm_v256i8_ty     : LLVMType<v256i8>;   //256 x i8
+
+def llvm_v1i16_ty      : LLVMType<v1i16>;    //  1 x i16
+def llvm_v2i16_ty      : LLVMType<v2i16>;    //  2 x i16
+def llvm_v4i16_ty      : LLVMType<v4i16>;    //  4 x i16
+def llvm_v8i16_ty      : LLVMType<v8i16>;    //  8 x i16
+def llvm_v16i16_ty     : LLVMType<v16i16>;   // 16 x i16
+def llvm_v32i16_ty     : LLVMType<v32i16>;   // 32 x i16
+def llvm_v64i16_ty     : LLVMType<v64i16>;   // 64 x i16
+def llvm_v128i16_ty    : LLVMType<v128i16>;  //128 x i16
+
+def llvm_v1i32_ty      : LLVMType<v1i32>;    //  1 x i32
+def llvm_v2i32_ty      : LLVMType<v2i32>;    //  2 x i32
+def llvm_v4i32_ty      : LLVMType<v4i32>;    //  4 x i32
+def llvm_v8i32_ty      : LLVMType<v8i32>;    //  8 x i32
+def llvm_v16i32_ty     : LLVMType<v16i32>;   // 16 x i32
+def llvm_v32i32_ty     : LLVMType<v32i32>;   // 32 x i32
+def llvm_v64i32_ty     : LLVMType<v64i32>;   // 64 x i32
+
+def llvm_v1i64_ty      : LLVMType<v1i64>;    //  1 x i64
+def llvm_v2i64_ty      : LLVMType<v2i64>;    //  2 x i64
+def llvm_v4i64_ty      : LLVMType<v4i64>;    //  4 x i64
+def llvm_v8i64_ty      : LLVMType<v8i64>;    //  8 x i64
+def llvm_v16i64_ty     : LLVMType<v16i64>;   // 16 x i64
+def llvm_v32i64_ty     : LLVMType<v32i64>;   // 32 x i64
+
+def llvm_v1i128_ty     : LLVMType<v1i128>;   //  1 x i128
+
+def llvm_v2f16_ty      : LLVMType<v2f16>;    //  2 x half (__fp16)
+def llvm_v4f16_ty      : LLVMType<v4f16>;    //  4 x half (__fp16)
+def llvm_v8f16_ty      : LLVMType<v8f16>;    //  8 x half (__fp16)
+def llvm_v1f32_ty      : LLVMType<v1f32>;    //  1 x float
+def llvm_v2f32_ty      : LLVMType<v2f32>;    //  2 x float
+def llvm_v4f32_ty      : LLVMType<v4f32>;    //  4 x float
+def llvm_v8f32_ty      : LLVMType<v8f32>;    //  8 x float
+def llvm_v16f32_ty     : LLVMType<v16f32>;   // 16 x float
+def llvm_v1f64_ty      : LLVMType<v1f64>;    //  1 x double
+def llvm_v2f64_ty      : LLVMType<v2f64>;    //  2 x double
+def llvm_v4f64_ty      : LLVMType<v4f64>;    //  4 x double
+def llvm_v8f64_ty      : LLVMType<v8f64>;    //  8 x double
+
+def llvm_vararg_ty     : LLVMType<isVoid>;   // this means vararg here
+
+
+//===----------------------------------------------------------------------===//
+// Intrinsic Definitions.
+//===----------------------------------------------------------------------===//
+
+// Intrinsic class - This is used to define one LLVM intrinsic.  The name of the
+// intrinsic definition should start with "int_", then match the LLVM intrinsic
+// name with the "llvm." prefix removed, and all "."s turned into "_"s.  For
+// example, llvm.bswap.i16 -> int_bswap_i16.
+//
+//  * RetTypes is a list containing the return types expected for the
+//    intrinsic.
+//  * ParamTypes is a list containing the parameter types expected for the
+//    intrinsic.
+//  * Properties can be set to describe the behavior of the intrinsic.
+//
+class SDPatternOperator;
+class Intrinsic<list<LLVMType> ret_types,
+                list<LLVMType> param_types = [],
+                list<IntrinsicProperty> properties = [],
+                string name = ""> : SDPatternOperator {
+  string LLVMName = name;
+  string TargetPrefix = "";   // Set to a prefix for target-specific intrinsics.
+  list<LLVMType> RetTypes = ret_types;
+  list<LLVMType> ParamTypes = param_types;
+  list<IntrinsicProperty> IntrProperties = properties;
+
+  bit isTarget = 0;
+}
+
+/// GCCBuiltin - If this intrinsic exactly corresponds to a GCC builtin, this
+/// specifies the name of the builtin.  This provides automatic CBE and CFE
+/// support.
+class GCCBuiltin<string name> {
+  string GCCBuiltinName = name;
+}
+
+class MSBuiltin<string name> {
+  string MSBuiltinName = name;
+}
+
+
+//===--------------- Variable Argument Handling Intrinsics ----------------===//
+//
+
+def int_vastart : Intrinsic<[], [llvm_ptr_ty], [], "llvm.va_start">;
+def int_vacopy  : Intrinsic<[], [llvm_ptr_ty, llvm_ptr_ty], [],
+                            "llvm.va_copy">;
+def int_vaend   : Intrinsic<[], [llvm_ptr_ty], [], "llvm.va_end">;
+
+//===------------------- Garbage Collection Intrinsics --------------------===//
+//
+def int_gcroot  : Intrinsic<[],
+                            [llvm_ptrptr_ty, llvm_ptr_ty]>;
+def int_gcread  : Intrinsic<[llvm_ptr_ty],
+                            [llvm_ptr_ty, llvm_ptrptr_ty],
+                            [IntrReadMem, IntrArgMemOnly]>;
+def int_gcwrite : Intrinsic<[],
+                            [llvm_ptr_ty, llvm_ptr_ty, llvm_ptrptr_ty],
+                            [IntrArgMemOnly, NoCapture<1>, NoCapture<2>]>;
+
+//===--------------------- Code Generator Intrinsics ----------------------===//
+//
+def int_returnaddress : Intrinsic<[llvm_ptr_ty], [llvm_i32_ty], [IntrNoMem]>;
+def int_addressofreturnaddress : Intrinsic<[llvm_ptr_ty], [], [IntrNoMem]>;
+def int_frameaddress  : Intrinsic<[llvm_ptr_ty], [llvm_i32_ty], [IntrNoMem]>;
+def int_read_register  : Intrinsic<[llvm_anyint_ty], [llvm_metadata_ty],
+                                   [IntrReadMem], "llvm.read_register">;
+def int_write_register : Intrinsic<[], [llvm_metadata_ty, llvm_anyint_ty],
+                                   [], "llvm.write_register">;
+
+// Gets the address of the local variable area. This is typically a copy of the
+// stack, frame, or base pointer depending on the type of prologue.
+def int_localaddress : Intrinsic<[llvm_ptr_ty], [], [IntrNoMem]>;
+
+// Escapes local variables to allow access from other functions.
+def int_localescape : Intrinsic<[], [llvm_vararg_ty]>;
+
+// Given a function and the localaddress of a parent frame, returns a pointer
+// to an escaped allocation indicated by the index.
+def int_localrecover : Intrinsic<[llvm_ptr_ty],
+                                 [llvm_ptr_ty, llvm_ptr_ty, llvm_i32_ty],
+                                 [IntrNoMem]>;
+// Note: we treat stacksave/stackrestore as writemem because we don't otherwise
+// model their dependencies on allocas.
+def int_stacksave     : Intrinsic<[llvm_ptr_ty]>,
+                        GCCBuiltin<"__builtin_stack_save">;
+def int_stackrestore  : Intrinsic<[], [llvm_ptr_ty]>,
+                        GCCBuiltin<"__builtin_stack_restore">;
+
+def int_get_dynamic_area_offset : Intrinsic<[llvm_anyint_ty]>;
+
+def int_thread_pointer : Intrinsic<[llvm_ptr_ty], [], [IntrNoMem]>,
+                         GCCBuiltin<"__builtin_thread_pointer">;
+
+// IntrInaccessibleMemOrArgMemOnly is a little more pessimistic than strictly
+// necessary for prefetch, however it does conveniently prevent the prefetch
+// from being reordered overly much with respect to nearby access to the same
+// memory while not impeding optimization.
+def int_prefetch
+    : Intrinsic<[], [ llvm_ptr_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty ],
+                [ IntrInaccessibleMemOrArgMemOnly, ReadOnly<0>, NoCapture<0> ]>;
+def int_pcmarker      : Intrinsic<[], [llvm_i32_ty]>;
+
+def int_readcyclecounter : Intrinsic<[llvm_i64_ty]>;
+
+// The assume intrinsic is marked as arbitrarily writing so that proper
+// control dependencies will be maintained.
+def int_assume        : Intrinsic<[], [llvm_i1_ty], []>;
+
+// Stack Protector Intrinsic - The stackprotector intrinsic writes the stack
+// guard to the correct place on the stack frame.
+def int_stackprotector : Intrinsic<[], [llvm_ptr_ty, llvm_ptrptr_ty], []>;
+def int_stackguard : Intrinsic<[llvm_ptr_ty], [], []>;
+
+// A counter increment for instrumentation based profiling.
+def int_instrprof_increment : Intrinsic<[],
+                                        [llvm_ptr_ty, llvm_i64_ty,
+                                         llvm_i32_ty, llvm_i32_ty],
+                                        []>;
+
+// A counter increment with step for instrumentation based profiling.
+def int_instrprof_increment_step : Intrinsic<[],
+                                        [llvm_ptr_ty, llvm_i64_ty,
+                                         llvm_i32_ty, llvm_i32_ty, llvm_i64_ty],
+                                        []>;
+
+// A call to profile runtime for value profiling of target expressions
+// through instrumentation based profiling.
+def int_instrprof_value_profile : Intrinsic<[],
+                                            [llvm_ptr_ty, llvm_i64_ty,
+                                             llvm_i64_ty, llvm_i32_ty,
+                                             llvm_i32_ty],
+                                            []>;
+
+//===------------------- Standard C Library Intrinsics --------------------===//
+//
+
+def int_memcpy  : Intrinsic<[],
+                             [llvm_anyptr_ty, llvm_anyptr_ty, llvm_anyint_ty,
+                              llvm_i32_ty, llvm_i1_ty],
+                            [IntrArgMemOnly, NoCapture<0>, NoCapture<1>,
+                             WriteOnly<0>, ReadOnly<1>]>;
+def int_memmove : Intrinsic<[],
+                            [llvm_anyptr_ty, llvm_anyptr_ty, llvm_anyint_ty,
+                             llvm_i32_ty, llvm_i1_ty],
+                            [IntrArgMemOnly, NoCapture<0>, NoCapture<1>,
+                             ReadOnly<1>]>;
+def int_memset  : Intrinsic<[],
+                            [llvm_anyptr_ty, llvm_i8_ty, llvm_anyint_ty,
+                             llvm_i32_ty, llvm_i1_ty],
+                            [IntrArgMemOnly, NoCapture<0>, WriteOnly<0>]>;
+
+// FIXME: Add version of these floating point intrinsics which allow non-default
+// rounding modes and FP exception handling.
+
+let IntrProperties = [IntrNoMem] in {
+  def int_fma  : Intrinsic<[llvm_anyfloat_ty],
+                           [LLVMMatchType<0>, LLVMMatchType<0>,
+                            LLVMMatchType<0>]>;
+  def int_fmuladd : Intrinsic<[llvm_anyfloat_ty],
+                              [LLVMMatchType<0>, LLVMMatchType<0>,
+                               LLVMMatchType<0>]>;
+
+  // These functions do not read memory, but are sensitive to the
+  // rounding mode. LLVM purposely does not model changes to the FP
+  // environment so they can be treated as readnone.
+  def int_sqrt : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_powi : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>, llvm_i32_ty]>;
+  def int_sin  : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_cos  : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_pow  : Intrinsic<[llvm_anyfloat_ty],
+                           [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_log  : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_log10: Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_log2 : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_exp  : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_exp2 : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_fabs : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_copysign : Intrinsic<[llvm_anyfloat_ty],
+                               [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_floor : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_ceil  : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_trunc : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_rint  : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_nearbyint : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_round : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_canonicalize : Intrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>],
+                                   [IntrNoMem]>;
+}
+
+def int_minnum : Intrinsic<[llvm_anyfloat_ty],
+  [LLVMMatchType<0>, LLVMMatchType<0>], [IntrNoMem, Commutative]
+>;
+def int_maxnum : Intrinsic<[llvm_anyfloat_ty],
+  [LLVMMatchType<0>, LLVMMatchType<0>], [IntrNoMem, Commutative]
+>;
+
+// NOTE: these are internal interfaces.
+def int_setjmp     : Intrinsic<[llvm_i32_ty],  [llvm_ptr_ty]>;
+def int_longjmp    : Intrinsic<[], [llvm_ptr_ty, llvm_i32_ty], [IntrNoReturn]>;
+def int_sigsetjmp  : Intrinsic<[llvm_i32_ty] , [llvm_ptr_ty, llvm_i32_ty]>;
+def int_siglongjmp : Intrinsic<[], [llvm_ptr_ty, llvm_i32_ty], [IntrNoReturn]>;
+
+// Internal interface for object size checking
+def int_objectsize : Intrinsic<[llvm_anyint_ty],
+                               [llvm_anyptr_ty, llvm_i1_ty, llvm_i1_ty],
+                               [IntrNoMem]>,
+                               GCCBuiltin<"__builtin_object_size">;
+
+//===--------------- Constrained Floating Point Intrinsics ----------------===//
+//
+
+let IntrProperties = [IntrInaccessibleMemOnly] in {
+  def int_experimental_constrained_fadd : Intrinsic<[ llvm_anyfloat_ty ],
+                                                    [ LLVMMatchType<0>,
+                                                      LLVMMatchType<0>,
+                                                      llvm_metadata_ty,
+                                                      llvm_metadata_ty ]>;
+  def int_experimental_constrained_fsub : Intrinsic<[ llvm_anyfloat_ty ],
+                                                    [ LLVMMatchType<0>,
+                                                      LLVMMatchType<0>,
+                                                      llvm_metadata_ty,
+                                                      llvm_metadata_ty ]>;
+  def int_experimental_constrained_fmul : Intrinsic<[ llvm_anyfloat_ty ],
+                                                    [ LLVMMatchType<0>,
+                                                      LLVMMatchType<0>,
+                                                      llvm_metadata_ty,
+                                                      llvm_metadata_ty ]>;
+  def int_experimental_constrained_fdiv : Intrinsic<[ llvm_anyfloat_ty ],
+                                                    [ LLVMMatchType<0>,
+                                                      LLVMMatchType<0>,
+                                                      llvm_metadata_ty,
+                                                      llvm_metadata_ty ]>;
+  def int_experimental_constrained_frem : Intrinsic<[ llvm_anyfloat_ty ],
+                                                    [ LLVMMatchType<0>,
+                                                      LLVMMatchType<0>,
+                                                      llvm_metadata_ty,
+                                                      llvm_metadata_ty ]>;
+}
+// FIXME: Add intrinsic for fcmp, fptrunc, fpext, fptoui and fptosi.
+
+
+//===------------------------- Expect Intrinsics --------------------------===//
+//
+def int_expect : Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>,
+                                              LLVMMatchType<0>], [IntrNoMem]>;
+
+//===-------------------- Bit Manipulation Intrinsics ---------------------===//
+//
+
+// None of these intrinsics accesses memory at all.
+let IntrProperties = [IntrNoMem] in {
+  def int_bswap: Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>]>;
+  def int_ctpop: Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>]>;
+  def int_ctlz : Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>, llvm_i1_ty]>;
+  def int_cttz : Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>, llvm_i1_ty]>;
+  def int_bitreverse : Intrinsic<[llvm_anyint_ty], [LLVMMatchType<0>]>;
+}
+
+//===------------------------ Debugger Intrinsics -------------------------===//
+//
+
+// None of these intrinsics accesses memory at all...but that doesn't mean the
+// optimizers can change them aggressively.  Special handling needed in a few
+// places.
+let IntrProperties = [IntrNoMem] in {
+  def int_dbg_declare      : Intrinsic<[],
+                                       [llvm_metadata_ty,
+                                       llvm_metadata_ty,
+                                       llvm_metadata_ty]>;
+  def int_dbg_value        : Intrinsic<[],
+                                       [llvm_metadata_ty, llvm_i64_ty,
+                                        llvm_metadata_ty,
+                                        llvm_metadata_ty]>;
+}
+
+//===------------------ Exception Handling Intrinsics----------------------===//
+//
+
+// The result of eh.typeid.for depends on the enclosing function, but inside a
+// given function it is 'const' and may be CSE'd etc.
+def int_eh_typeid_for : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrNoMem]>;
+
+def int_eh_return_i32 : Intrinsic<[], [llvm_i32_ty, llvm_ptr_ty]>;
+def int_eh_return_i64 : Intrinsic<[], [llvm_i64_ty, llvm_ptr_ty]>;
+
+// eh.exceptionpointer returns the pointer to the exception caught by
+// the given `catchpad`.
+def int_eh_exceptionpointer : Intrinsic<[llvm_anyptr_ty], [llvm_token_ty],
+                                        [IntrNoMem]>;
+
+// Gets the exception code from a catchpad token. Only used on some platforms.
+def int_eh_exceptioncode : Intrinsic<[llvm_i32_ty], [llvm_token_ty], [IntrNoMem]>;
+
+// __builtin_unwind_init is an undocumented GCC intrinsic that causes all
+// callee-saved registers to be saved and restored (regardless of whether they
+// are used) in the calling function. It is used by libgcc_eh.
+def int_eh_unwind_init: Intrinsic<[]>,
+                        GCCBuiltin<"__builtin_unwind_init">;
+
+def int_eh_dwarf_cfa  : Intrinsic<[llvm_ptr_ty], [llvm_i32_ty]>;
+
+let IntrProperties = [IntrNoMem] in {
+  def int_eh_sjlj_lsda             : Intrinsic<[llvm_ptr_ty]>;
+  def int_eh_sjlj_callsite         : Intrinsic<[], [llvm_i32_ty]>;
+}
+def int_eh_sjlj_functioncontext : Intrinsic<[], [llvm_ptr_ty]>;
+def int_eh_sjlj_setjmp          : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty]>;
+def int_eh_sjlj_longjmp         : Intrinsic<[], [llvm_ptr_ty], [IntrNoReturn]>;
+def int_eh_sjlj_setup_dispatch  : Intrinsic<[], []>;
+
+//===---------------- Generic Variable Attribute Intrinsics----------------===//
+//
+def int_var_annotation : Intrinsic<[],
+                                   [llvm_ptr_ty, llvm_ptr_ty,
+                                    llvm_ptr_ty, llvm_i32_ty],
+                                   [], "llvm.var.annotation">;
+def int_ptr_annotation : Intrinsic<[LLVMAnyPointerType<llvm_anyint_ty>],
+                                   [LLVMMatchType<0>, llvm_ptr_ty, llvm_ptr_ty,
+                                    llvm_i32_ty],
+                                   [], "llvm.ptr.annotation">;
+def int_annotation : Intrinsic<[llvm_anyint_ty],
+                               [LLVMMatchType<0>, llvm_ptr_ty,
+                                llvm_ptr_ty, llvm_i32_ty],
+                               [], "llvm.annotation">;
+
+//===------------------------ Trampoline Intrinsics -----------------------===//
+//
+def int_init_trampoline : Intrinsic<[],
+                                    [llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
+                                    [IntrArgMemOnly, NoCapture<0>]>,
+                                   GCCBuiltin<"__builtin_init_trampoline">;
+
+def int_adjust_trampoline : Intrinsic<[llvm_ptr_ty], [llvm_ptr_ty],
+                                      [IntrReadMem, IntrArgMemOnly]>,
+                                     GCCBuiltin<"__builtin_adjust_trampoline">;
+
+//===------------------------ Overflow Intrinsics -------------------------===//
+//
+
+// Expose the carry flag from add operations on two integrals.
+def int_sadd_with_overflow : Intrinsic<[llvm_anyint_ty, llvm_i1_ty],
+                                       [LLVMMatchType<0>, LLVMMatchType<0>],
+                                       [IntrNoMem]>;
+def int_uadd_with_overflow : Intrinsic<[llvm_anyint_ty, llvm_i1_ty],
+                                       [LLVMMatchType<0>, LLVMMatchType<0>],
+                                       [IntrNoMem]>;
+
+def int_ssub_with_overflow : Intrinsic<[llvm_anyint_ty, llvm_i1_ty],
+                                       [LLVMMatchType<0>, LLVMMatchType<0>],
+                                       [IntrNoMem]>;
+def int_usub_with_overflow : Intrinsic<[llvm_anyint_ty, llvm_i1_ty],
+                                       [LLVMMatchType<0>, LLVMMatchType<0>],
+                                       [IntrNoMem]>;
+
+def int_smul_with_overflow : Intrinsic<[llvm_anyint_ty, llvm_i1_ty],
+                                       [LLVMMatchType<0>, LLVMMatchType<0>],
+                                       [IntrNoMem]>;
+def int_umul_with_overflow : Intrinsic<[llvm_anyint_ty, llvm_i1_ty],
+                                       [LLVMMatchType<0>, LLVMMatchType<0>],
+                                       [IntrNoMem]>;
+
+//===------------------------- Memory Use Markers -------------------------===//
+//
+def int_lifetime_start  : Intrinsic<[],
+                                    [llvm_i64_ty, llvm_anyptr_ty],
+                                    [IntrArgMemOnly, NoCapture<1>]>;
+def int_lifetime_end    : Intrinsic<[],
+                                    [llvm_i64_ty, llvm_anyptr_ty],
+                                    [IntrArgMemOnly, NoCapture<1>]>;
+def int_invariant_start : Intrinsic<[llvm_descriptor_ty],
+                                    [llvm_i64_ty, llvm_anyptr_ty],
+                                    [IntrArgMemOnly, NoCapture<1>]>;
+def int_invariant_end   : Intrinsic<[],
+                                    [llvm_descriptor_ty, llvm_i64_ty,
+                                     llvm_anyptr_ty],
+                                    [IntrArgMemOnly, NoCapture<2>]>;
+
+// invariant.group.barrier can't be marked with 'readnone' (IntrNoMem),
+// because it would cause CSE of two barriers with the same argument.
+// Readonly and argmemonly says that barrier only reads its argument and
+// it can be CSE only if memory didn't change between 2 barriers call,
+// which is valid.
+// The argument also can't be marked with 'returned' attribute, because
+// it would remove barrier. 
+def int_invariant_group_barrier : Intrinsic<[llvm_ptr_ty],
+                                            [llvm_ptr_ty],
+                                            [IntrReadMem, IntrArgMemOnly]>;
+
+//===------------------------ Stackmap Intrinsics -------------------------===//
+//
+def int_experimental_stackmap : Intrinsic<[],
+                                  [llvm_i64_ty, llvm_i32_ty, llvm_vararg_ty],
+                                  [Throws]>;
+def int_experimental_patchpoint_void : Intrinsic<[],
+                                                 [llvm_i64_ty, llvm_i32_ty,
+                                                  llvm_ptr_ty, llvm_i32_ty,
+                                                  llvm_vararg_ty],
+                                                  [Throws]>;
+def int_experimental_patchpoint_i64 : Intrinsic<[llvm_i64_ty],
+                                                [llvm_i64_ty, llvm_i32_ty,
+                                                 llvm_ptr_ty, llvm_i32_ty,
+                                                 llvm_vararg_ty],
+                                                 [Throws]>;
+
+
+//===------------------------ Garbage Collection Intrinsics ---------------===//
+// These are documented in docs/Statepoint.rst
+
+def int_experimental_gc_statepoint : Intrinsic<[llvm_token_ty],
+                               [llvm_i64_ty, llvm_i32_ty,
+                                llvm_anyptr_ty, llvm_i32_ty,
+                                llvm_i32_ty, llvm_vararg_ty],
+                                [Throws]>;
+
+def int_experimental_gc_result   : Intrinsic<[llvm_any_ty], [llvm_token_ty],
+                                             [IntrReadMem]>;
+def int_experimental_gc_relocate : Intrinsic<[llvm_any_ty],
+                                [llvm_token_ty, llvm_i32_ty, llvm_i32_ty],
+                                [IntrReadMem]>;
+
+//===------------------------ Coroutine Intrinsics ---------------===//
+// These are documented in docs/Coroutines.rst
+
+// Coroutine Structure Intrinsics.
+
+def int_coro_id : Intrinsic<[llvm_token_ty], [llvm_i32_ty, llvm_ptr_ty,
+                             llvm_ptr_ty, llvm_ptr_ty],
+                            [IntrArgMemOnly, IntrReadMem,
+                             ReadNone<1>, ReadOnly<2>, NoCapture<2>]>;
+def int_coro_alloc : Intrinsic<[llvm_i1_ty], [llvm_token_ty], []>;
+def int_coro_begin : Intrinsic<[llvm_ptr_ty], [llvm_token_ty, llvm_ptr_ty],
+                               [WriteOnly<1>]>;
+
+def int_coro_free : Intrinsic<[llvm_ptr_ty], [llvm_token_ty, llvm_ptr_ty],
+                              [IntrReadMem, IntrArgMemOnly, ReadOnly<1>,
+                               NoCapture<1>]>;
+def int_coro_end : Intrinsic<[llvm_i1_ty], [llvm_ptr_ty, llvm_i1_ty], []>;
+
+def int_coro_frame : Intrinsic<[llvm_ptr_ty], [], [IntrNoMem]>;
+def int_coro_size : Intrinsic<[llvm_anyint_ty], [], [IntrNoMem]>;
+
+def int_coro_save : Intrinsic<[llvm_token_ty], [llvm_ptr_ty], []>;
+def int_coro_suspend : Intrinsic<[llvm_i8_ty], [llvm_token_ty, llvm_i1_ty], []>;
+
+def int_coro_param : Intrinsic<[llvm_i1_ty], [llvm_ptr_ty, llvm_ptr_ty],
+                               [IntrNoMem, ReadNone<0>, ReadNone<1>]>;
+
+// Coroutine Manipulation Intrinsics.
+
+def int_coro_resume : Intrinsic<[], [llvm_ptr_ty], [Throws]>;
+def int_coro_destroy : Intrinsic<[], [llvm_ptr_ty], [Throws]>;
+def int_coro_done : Intrinsic<[llvm_i1_ty], [llvm_ptr_ty],
+                              [IntrArgMemOnly, ReadOnly<0>, NoCapture<0>]>;
+def int_coro_promise : Intrinsic<[llvm_ptr_ty],
+                                 [llvm_ptr_ty, llvm_i32_ty, llvm_i1_ty],
+                                 [IntrNoMem, NoCapture<0>]>;
+
+// Coroutine Lowering Intrinsics. Used internally by coroutine passes.
+
+def int_coro_subfn_addr : Intrinsic<[llvm_ptr_ty], [llvm_ptr_ty, llvm_i8_ty],
+                                    [IntrReadMem, IntrArgMemOnly, ReadOnly<0>,
+                                     NoCapture<0>]>;
+
+///===-------------------------- Other Intrinsics --------------------------===//
+//
+def int_flt_rounds : Intrinsic<[llvm_i32_ty]>,
+                     GCCBuiltin<"__builtin_flt_rounds">;
+def int_trap : Intrinsic<[], [], [IntrNoReturn]>,
+               GCCBuiltin<"__builtin_trap">;
+def int_debugtrap : Intrinsic<[]>,
+                    GCCBuiltin<"__builtin_debugtrap">;
+
+// Support for dynamic deoptimization (or de-specialization)
+def int_experimental_deoptimize : Intrinsic<[llvm_any_ty], [llvm_vararg_ty],
+                                            [Throws]>;
+
+// Support for speculative runtime guards
+def int_experimental_guard : Intrinsic<[], [llvm_i1_ty, llvm_vararg_ty],
+                                       [Throws]>;
+
+// NOP: calls/invokes to this intrinsic are removed by codegen
+def int_donothing : Intrinsic<[], [], [IntrNoMem]>;
+
+// Intrisics to support half precision floating point format
+let IntrProperties = [IntrNoMem] in {
+def int_convert_to_fp16   : Intrinsic<[llvm_i16_ty], [llvm_anyfloat_ty]>;
+def int_convert_from_fp16 : Intrinsic<[llvm_anyfloat_ty], [llvm_i16_ty]>;
+}
+
+// Clear cache intrinsic, default to ignore (ie. emit nothing)
+// maps to void __clear_cache() on supporting platforms
+def int_clear_cache : Intrinsic<[], [llvm_ptr_ty, llvm_ptr_ty],
+                                [], "llvm.clear_cache">;
+
+//===-------------------------- Masked Intrinsics -------------------------===//
+//
+def int_masked_store : Intrinsic<[], [llvm_anyvector_ty,
+                                      LLVMAnyPointerType<LLVMMatchType<0>>,
+                                      llvm_i32_ty,
+                                      LLVMVectorSameWidth<0, llvm_i1_ty>],
+                                 [IntrArgMemOnly]>;
+
+def int_masked_load  : Intrinsic<[llvm_anyvector_ty],
+                                 [LLVMAnyPointerType<LLVMMatchType<0>>, llvm_i32_ty,
+                                  LLVMVectorSameWidth<0, llvm_i1_ty>, LLVMMatchType<0>],
+                                 [IntrReadMem, IntrArgMemOnly]>;
+
+def int_masked_gather: Intrinsic<[llvm_anyvector_ty],
+                                 [LLVMVectorOfPointersToElt<0>, llvm_i32_ty,
+                                  LLVMVectorSameWidth<0, llvm_i1_ty>,
+                                  LLVMMatchType<0>],
+                                 [IntrReadMem]>;
+
+def int_masked_scatter: Intrinsic<[],
+                                  [llvm_anyvector_ty,
+                                   LLVMVectorOfPointersToElt<0>, llvm_i32_ty,
+                                   LLVMVectorSameWidth<0, llvm_i1_ty>]>;
+
+def int_masked_expandload: Intrinsic<[llvm_anyvector_ty],
+                                     [LLVMPointerToElt<0>,
+                                      LLVMVectorSameWidth<0, llvm_i1_ty>,
+                                      LLVMMatchType<0>],
+                                     [IntrReadMem]>;
+
+def int_masked_compressstore: Intrinsic<[],
+                                     [llvm_anyvector_ty,
+                                      LLVMPointerToElt<0>,
+                                      LLVMVectorSameWidth<0, llvm_i1_ty>],
+                                     [IntrArgMemOnly]>;
+
+// Test whether a pointer is associated with a type metadata identifier.
+def int_type_test : Intrinsic<[llvm_i1_ty], [llvm_ptr_ty, llvm_metadata_ty],
+                              [IntrNoMem]>;
+
+// Safely loads a function pointer from a virtual table pointer using type metadata.
+def int_type_checked_load : Intrinsic<[llvm_ptr_ty, llvm_i1_ty],
+                                      [llvm_ptr_ty, llvm_i32_ty, llvm_metadata_ty],
+                                      [IntrNoMem]>;
+
+def int_load_relative: Intrinsic<[llvm_ptr_ty], [llvm_ptr_ty, llvm_anyint_ty],
+                                 [IntrReadMem, IntrArgMemOnly]>;
+
+//===------ Memory intrinsics with element-wise atomicity guarantees ------===//
+//
+
+def int_memcpy_element_atomic  : Intrinsic<[],
+                                           [llvm_anyptr_ty, llvm_anyptr_ty,
+                                            llvm_i64_ty, llvm_i32_ty],
+                                 [IntrArgMemOnly, NoCapture<0>, NoCapture<1>,
+                                  WriteOnly<0>, ReadOnly<1>]>;
+
+//===----- Intrinsics that are used to provide predicate information -----===//
+
+def int_ssa_copy : Intrinsic<[llvm_any_ty], [LLVMMatchType<0>],
+                             [IntrNoMem, Returned<0>]>;
+//===----------------------------------------------------------------------===//
+// Target-specific intrinsics
+//===----------------------------------------------------------------------===//
+
+include "llvm/IR/IntrinsicsPowerPC.td"
+include "llvm/IR/IntrinsicsX86.td"
+include "llvm/IR/IntrinsicsARM.td"
+include "llvm/IR/IntrinsicsAArch64.td"
+include "llvm/IR/IntrinsicsXCore.td"
+include "llvm/IR/IntrinsicsHexagon.td"
+include "llvm/IR/IntrinsicsNVVM.td"
+include "llvm/IR/IntrinsicsMips.td"
+include "llvm/IR/IntrinsicsAMDGPU.td"
+include "llvm/IR/IntrinsicsBPF.td"
+include "llvm/IR/IntrinsicsSystemZ.td"
+include "llvm/IR/IntrinsicsWebAssembly.td"

--- a/utils/intrinsics-gen.swift
+++ b/utils/intrinsics-gen.swift
@@ -1,0 +1,1302 @@
+import Foundation
+#if os(Linux)
+  import Glibc
+#else
+  import Darwin
+#endif
+
+// Object ::=
+enum Object {
+  // Class |
+  case classDecl(ClassDecl)
+  // Def |
+  case def(RecordDefinition)
+  // Defm |
+  case defm(RecordDefinition)
+  // Let |
+  case letDecl(Let)
+  // MultiClass |
+  case multiClassDecl(ClassDecl)
+  // ForEach
+  // case forEach(...)
+
+  // TableGen has an include mechanism. It does not play a role in the syntax
+  // per se, since it is lexically replaced with the contents of the included file.
+  case include(Include)
+}
+
+// Class ::=  "class" TokIdentifier [TemplateArgList] ObjectBody
+struct ClassDecl {
+  struct TemplateArgument {
+    let type: TDType
+    let name: String
+    let valueBinding: Optional<TDValue>
+
+    init(_ type: TDType, _ name: String, _ valueBinding: Optional<TDValue>) {
+      self.type = type
+      self.name = name
+      self.valueBinding = valueBinding
+    }
+  }
+
+  // Name ::= TokIdentifier
+  let name: String
+  // TemplateArgList ::=  "<" Declaration ("," Declaration)* ">"
+  let args: Array<TemplateArgument>
+  // BaseClassList   ::=  [":" BaseClassListNE]
+  let baseClassList: Array<TDType>
+}
+
+// Def ::=  "def" TokIdentifier ObjectBody
+final class RecordDefinition {
+  // Name ::= TokIdentifier
+  let name: String
+  // BaseClassList   ::=  [":" BaseClassListNE]
+  var baseClassList: Array<TDType>
+
+  init(name : String, baseClassList : Array<TDType>) {
+    self.name = name
+    self.baseClassList = baseClassList
+  }
+}
+
+// Let     ::=   "let" LetList "in" "{" Object* "}"
+//             | "let" LetList "in" Object
+// LetList ::=  LetItem ("," LetItem)*
+// LetItem ::=  TokIdentifier [RangeList] "=" Value
+struct Let {
+  // n.b. We currently don't care about the content of let-bindings.
+  let objects: Array<Object>
+}
+
+// IncludeDirective ::=  "include" TokString
+struct Include {
+  let path: String
+  let objects: Array<Object>
+}
+
+enum TDValue {
+  case list(Array<TDValue>)
+  case stringConcat(Array<TDValue>)
+  case type(TDType)
+  case string(String)
+  case int(Int)
+}
+
+struct TDType {
+  let name: String
+  let args: Array<TDValue>
+}
+
+enum Token : Equatable, CustomDebugStringConvertible {
+  case identifier(String)
+  case int(Int)
+  case string(String)
+  case angles(Array<Token>)
+  case squares(Array<Token>)
+  case braces(Array<Token>)
+  case parens(Array<Token>)
+  case colon
+  case comma
+  case semicolon
+  case equals
+  case bang
+
+  static func == (lhs: Token, rhs: Token) -> Bool {
+    switch (lhs, rhs) {
+    case let (.identifier(l), .identifier(r)):
+      return l == r
+    case let (.int(l), .int(r)):
+      return l == r
+    case let (.string(l), .string(r)):
+      return l == r
+    case let (.angles(l), .angles(r)):
+      return l == r
+    case let (.squares(l), .squares(r)):
+      return l == r
+    case let (.braces(l), .braces(r)):
+      return l == r
+    case let (.parens(l), .parens(r)):
+      return l == r
+    case (.colon, .colon):
+      return true
+    case (.comma, .comma):
+      return true
+    case (.semicolon, .semicolon):
+      return true
+    case (.equals, .equals):
+      return true
+    case (.bang, .bang):
+      return true
+    default:
+      return false
+    }
+  }
+
+  var debugDescription: String {
+    switch self {
+    case .colon:
+      return " : "
+    case .comma:
+      return " , "
+    case .semicolon:
+      return " ; "
+    case .equals:
+      return " = "
+    case .bang:
+      return "!"
+    case let .identifier(i):
+      return i
+    case let .int(i):
+      return "\(i)"
+    case let .string(s):
+      return "\"\(s)\""
+    case let .angles(toks):
+      return "<" + toks.map({ $0.debugDescription }).joined(separator: ", ") + ">"
+    case let .squares(toks):
+      return "[" + toks.map({ $0.debugDescription }).joined(separator: ", ") + "]"
+    case let .braces(toks):
+      return "{" + toks.map({ $0.debugDescription }).joined(separator: ", ") + "}"
+    case let .parens(toks):
+      return "(" + toks.map({ $0.debugDescription }).joined(separator: ", ") + ")"
+    }
+  }
+}
+
+extension Character {
+  var utf8CodePoint : CChar {
+    return String(self).cString(using: .utf8)!.first!
+  }
+
+  fileprivate var isWhitespace : Bool {
+    let utf8Value = self.utf8CodePoint
+    return isspace(Int32(utf8Value)) != 0
+  }
+}
+
+func tokenize(_ str: String, with lexRE: NSRegularExpression) -> Array<Token> {
+  var stack = [[Token]]()
+  var tokenStream = [Token]()
+  var s = Substring(str)
+  while !s.isEmpty && s.first!.isWhitespace {
+    // will fail with non-ascii whitespace
+    s = s.dropFirst()
+  }
+
+  while !s.isEmpty {
+    let skipLength : Int;
+    switch s.first! {
+    case ":":
+      tokenStream.append(.colon)
+      skipLength = 1
+    case ",":
+      tokenStream.append(.comma)
+      skipLength = 1
+    case ";":
+      tokenStream.append(.semicolon)
+      skipLength = 1
+    case "=":
+      tokenStream.append(.equals)
+      skipLength = 1
+    case "!":
+      tokenStream.append(.bang)
+      skipLength = 1
+    case "\"":
+      guard let lexRE = try? NSRegularExpression(pattern: "^\"(.*?)\"") else {
+        fatalError()
+      }
+      let strBuf = String(s)
+      let string = lexRE.matches(in: strBuf, range: NSRange(location: 0, length: strBuf.utf8.count))[0]
+      let r = string.range
+      tokenStream.append(.string(String(strBuf[
+        Range<String.Index>(
+          uncheckedBounds: (
+            strBuf.index(strBuf.startIndex, offsetBy: r.location),
+            strBuf.index(strBuf.startIndex, offsetBy: NSMaxRange(r))
+          )
+        )
+        ])))
+      skipLength = NSMaxRange(r)
+    case "0"..."9":
+      guard let lexRE = try? NSRegularExpression(pattern: "^[0-9]+") else {
+        fatalError()
+      }
+      let strBuf = String(s)
+      let string = lexRE.matches(in: strBuf, range: NSRange(location: 0, length: strBuf.utf8.count))[0]
+      let r = string.range
+      tokenStream.append(Token.int(Int(String(strBuf[
+        Range<String.Index>(
+          uncheckedBounds: (
+            strBuf.index(strBuf.startIndex, offsetBy: r.location),
+            strBuf.index(strBuf.startIndex, offsetBy: NSMaxRange(r))
+          )
+        )
+        ]))!))
+      skipLength = NSMaxRange(r)
+    case "<": fallthrough
+    case "(": fallthrough
+    case "{": fallthrough
+    case "[":
+      stack.append(tokenStream)
+      tokenStream.removeAll()
+      skipLength = 1
+    case ">":
+      let tok = Token.angles(tokenStream)
+      tokenStream = stack.popLast()! + [tok]
+      skipLength = 1
+    case "}":
+      let tok = Token.braces(tokenStream)
+      tokenStream = stack.popLast()! + [tok]
+      skipLength = 1
+    case "]":
+      let tok = Token.squares(tokenStream)
+      tokenStream = stack.popLast()! + [tok]
+      skipLength = 1
+    case ")":
+      let tok = Token.parens(tokenStream)
+      tokenStream = stack.popLast()! + [tok]
+      skipLength = 1
+    // comment
+    case "/":
+      skipLength = s.split(whereSeparator: { c in c == "\n" }).first!.utf8.count
+    case let c where c.isWhitespace:
+      skipLength = 0
+    default:
+      let strBuf = String(s)
+      let string = lexRE.matches(in: strBuf, range: NSRange(location: 0, length: strBuf.utf8.count))[0]
+      let r = string.range
+      tokenStream.append(Token.identifier(String(strBuf[
+        Range<String.Index>(
+          uncheckedBounds: (
+            strBuf.index(strBuf.startIndex, offsetBy: r.location),
+            strBuf.index(strBuf.startIndex, offsetBy: NSMaxRange(r))
+          )
+        )
+        ])))
+      skipLength = NSMaxRange(r)
+    }
+
+    s = s.dropFirst(skipLength)
+    while !s.isEmpty && s.first!.isWhitespace {
+      // will fail with non-ascii whitespace
+      s = s.dropFirst()
+    }
+  }
+
+  assert(stack.isEmpty)
+  return tokenStream
+}
+
+
+func extractDefinitions(_ items: Array<Object>) -> (classes: Array<ClassDecl>, records: Array<RecordDefinition>) {
+  var classes = [ClassDecl]()
+  var defs = [RecordDefinition]()
+  for it in items {
+    switch it {
+    case let .letDecl(letStream):
+      let defns = extractDefinitions(letStream.objects)
+      classes.append(contentsOf: defns.classes)
+      defs.append(contentsOf: defns.records)
+    case let .include(includeStream):
+      let defns = extractDefinitions(includeStream.objects)
+      classes.append(contentsOf: defns.classes)
+      defs.append(contentsOf: defns.records)
+    case let .classDecl(c):
+      classes.append(c)
+    case let .def(d):
+      defs.append(d)
+    // Ignore multiclasses and multidefs for now.
+    case .defm(_), .multiClassDecl(_): break
+    }
+  }
+  return (classes, defs)
+}
+
+func resolveClasses(_ defs: [RecordDefinition], _ classes: Dictionary<String, ClassDecl>) {
+  func performTypeSubstitution(_ types: inout Array<TDType>, _ ty: TDType, _ classes: Dictionary<String, ClassDecl>,
+                               _ args: Dictionary<String, TDValue>) {
+    guard let resolvedClass : ClassDecl = classes[ty.name] else {
+      types.append(ty)
+      return
+    }
+
+    let tyArgs = ty.args.map(Optional.some)
+    let argSeq : UnfoldSequence<Optional<TDValue>, (Optional<TDValue>?, Bool)>
+    if tyArgs.isEmpty {
+      argSeq = sequence(first: nil, next: { _ in nil })
+    } else {
+      var idx = 1
+      argSeq = sequence(first: tyArgs[0], next: { _ in
+        defer { idx += 1 }
+        if idx < tyArgs.count {
+          return tyArgs[idx]
+        }
+        return .some(Optional<TDValue>.none)
+      })
+    }
+
+    let boundArgs = zip(argSeq, resolvedClass.args).map({ (t) -> TDValue in
+      let (left, right) = t
+      return left.map({ v in substitute(v, args) }) ?? right.valueBinding!
+    })
+
+    let arg_dict = zip(boundArgs, resolvedClass.args).map({ (t) -> (String, TDValue) in
+      let (val, right) = t
+      return (right.name, val)
+    })
+
+    for superClass in resolvedClass.baseClassList {
+      performTypeSubstitution(&types, superClass, classes, Dictionary(uniqueKeysWithValues: arg_dict))
+    }
+
+    types.append(TDType(name: ty.name, args: boundArgs))
+  }
+
+  func substitute(_ val: TDValue, _ rules: Dictionary<String, TDValue>) -> TDValue {
+    switch val {
+    case .type(let ty):
+      switch rules[ty.name] {
+      case let .some(new):
+        assert(ty.args.isEmpty)
+        return new
+      case .none: return val
+      }
+
+    case .list(let vals):
+      return TDValue.list(vals.map({ v in substitute(v, rules) }))
+
+    case .stringConcat(let vals):
+      let new = vals.map({ v in substitute(v, rules) })
+      if new.reduce(true, { (acc, s) in
+        switch s {
+        case .string(_): return true && acc
+        default: return false
+        }
+      }) {
+        return TDValue.string(new.map({ (s) -> String in
+          switch s {
+          case .string(let s):
+            return s
+          default:
+            fatalError()
+          }
+        }).joined())
+      } else {
+        return .stringConcat(new)
+      }
+
+    default:
+      return val
+    }
+  }
+
+  for d in defs {
+    let empty = Dictionary<String, TDValue>()
+    var substituteList = [TDType]()
+    for sup in d.baseClassList {
+      performTypeSubstitution(&substituteList, sup, classes, empty)
+    }
+    d.baseClassList = substituteList
+  }
+}
+
+struct Parser<S: IteratorProtocol> where S.Element == Token {
+  var tokens: S
+  let root: String
+
+
+  func subparser<T: IteratorProtocol>(_ iter: T) -> Parser<T>
+    where T.Element == Token
+  {
+    return Parser<T>(
+      tokens: iter,
+      root: self.root
+    )
+  }
+
+
+  mutating func parseTableGen() -> Array<Object> {
+    var ret = [Object]()
+    while let item = self.maybeParseObject() {
+      ret.append(item)
+    }
+    return ret
+  }
+
+  mutating func maybeParseObject() -> Optional<Object> {
+    return self.maybeParseIdentifier().map({ (ident) -> Object in
+      switch ident {
+      case "class":
+        return Object.classDecl(self.parseClass())
+      case "def":
+        return Object.def(self.parseRecordDefinition())
+      case "defm":
+        return Object.defm(self.parseRecordDefinition())
+      case "let":
+        return Object.letDecl(self.parseLet())
+      case "multiclass":
+        return Object.multiClassDecl(self.parseClass())
+      case "include":
+        return Object.include(self.parseInclude())
+      default:
+        fatalError("unexpected keyword \(ident)")
+      }
+    })
+  }
+
+  mutating func consumeToken() -> Token {
+    return self.tokens.next()!
+  }
+
+  mutating func consume(_ expected: Token) {
+    expect(self.consumeToken(), expected)
+  }
+
+  mutating func maybeParseIdentifier() -> Optional<String> {
+    return self.tokens.next().map(expectIdentifier)
+  }
+
+  mutating func parseIdentifier() -> String {
+    guard let ident = self.maybeParseIdentifier() else {
+      fatalError("Unexpected EOF while parsing identifier")
+    }
+    return ident
+  }
+
+  mutating func parseClass() -> ClassDecl {
+    let name = self.parseIdentifier()
+
+    let (args, tok) = { () -> (Array<ClassDecl.TemplateArgument>, Token) in
+      switch self.consumeToken() {
+      case let Token.angles(contents):
+        var args = Array<ClassDecl.TemplateArgument>()
+        var subparser = self.subparser(contents.makeIterator())
+        while let (ty, tok) = subparser.maybeParseType(nil) {
+          let name = expectIdentifier(tok ?? subparser.consumeToken())
+          let (next, val) = { () -> (Token?, TDValue?) in
+            switch subparser.tokens.next() {
+            case .some(Token.equals):
+              let (val, tok) = subparser.maybeParseValueBinding()!
+              return (tok ?? subparser.tokens.next(), .some(val))
+            case let tok:
+              return (tok, nil)
+            }
+          }()
+
+          args.append(ClassDecl.TemplateArgument(ty, name, val))
+          switch next {
+          case let .some(tok):
+            expect(tok, .comma)
+          case .none:
+            break
+          }
+        }
+        return (args, self.consumeToken())
+      case let tok:
+        return ([], tok)
+      }
+    }()
+
+    let parsedInhClause = { () -> Array<TDType> in
+      switch tok {
+      case Token.semicolon, Token.braces(_):
+        return []
+      case Token.colon:
+        return self.parseInheritanceClause()
+      case let tok:
+        fatalError("while parsing inheritance list, expected : or {{...}}, found \(tok)")
+      }
+    }()
+    return ClassDecl(name: name, args: args, baseClassList: parsedInhClause)
+  }
+
+  mutating func parseRecordDefinition() -> RecordDefinition {
+    let name = self.parseIdentifier()
+    self.consume(.colon)
+    let inherits = self.parseInheritanceClause()
+    return RecordDefinition(name: name, baseClassList: inherits)
+  }
+
+  mutating func parseLet() -> Let {
+    _ = self.parseIdentifier()
+    self.consume(Token.equals)
+    switch self.consumeToken() {
+    case Token.squares(_), Token.string(_), Token.int(_):
+      break
+    case let tok:
+      fatalError("while parsing let binding, expected [...], string or int, found \(tok)")
+    }
+    self.consume(Token.identifier("in"))
+    switch self.consumeToken() {
+    case let Token.braces(contents):
+      var subparser = self.subparser(contents.makeIterator())
+      let items = subparser.parseTableGen()
+      return Let(objects: items)
+    case let tok:
+      fatalError("expected {{...}}, found \(tok)")
+    }
+  }
+
+  mutating func parseInclude() -> Include {
+    guard case let Token.string(path) = self.consumeToken() else {
+      fatalError("expected string")
+    }
+
+    // ignore includes for now
+    return Include(path: path, objects: [])
+  }
+
+  mutating func parseInheritanceClause() -> Array<TDType> {
+    var ret = Array<TDType>()
+
+    var shouldBreak = false
+    repeat {
+      let (ty, tok) = self.maybeParseType(.none)!
+      ret.append(ty)
+
+      switch tok ?? self.consumeToken() {
+      case Token.comma: break
+
+      case Token.semicolon, Token.braces(_):
+        shouldBreak = true
+      case let tok:
+        fatalError("while parsing inheritance clause, expected ','  or {{...}}, found \(tok)")
+      }
+    } while (!shouldBreak)
+    return ret
+  }
+
+  mutating func maybeParseType(_ first: Optional<Token>) -> Optional<(TDType, Optional<Token>)> {
+    return (first.map(expectIdentifier) ?? self.maybeParseIdentifier()).map({ name in
+      switch self.tokens.next() {
+      case let .some(Token.angles(contents)):
+        var subparser = self.subparser(contents.makeIterator())
+        let vals = subparser.parseValueList()
+        return (TDType(
+          name: name,
+          args: vals
+        ), nil)
+      case let tok:
+        return (TDType(name: name, args: []), tok)
+      }
+    })
+  }
+
+  mutating func parseValueList() -> Array<TDValue> {
+    var ret = Array<TDValue>()
+    while let (val, tok) = self.maybeParseValueBinding() {
+      ret.append(val)
+
+      guard let tol = tok ?? self.tokens.next() else {
+        break
+      }
+      expect(tol, .comma)
+    }
+    return ret
+  }
+
+  mutating func maybeParseValueBinding() -> Optional<(TDValue, Optional<Token>)> {
+    return self.tokens.next().map({ tok in
+      switch tok {
+      case let Token.int(n):
+        return (TDValue.int(n), nil)
+      case let Token.string(s):
+        return (TDValue.string(s), nil)
+      case let Token.squares(contents):
+        var subparser = self.subparser(contents.makeIterator())
+        let vals = subparser.parseValueList()
+        return (TDValue.list(vals), nil)
+      case Token.bang:
+        self.consume(Token.identifier("strconcat"))
+        switch self.consumeToken() {
+        case let Token.parens(contents):
+          var subparser = self.subparser(contents.makeIterator())
+          let vals = subparser.parseValueList()
+          return (TDValue.stringConcat(vals), nil)
+        case let tok:
+          fatalError("expected (...), found \(tok)")
+        }
+      default:
+        let (ty, tyTok) = self.maybeParseType(.some(tok))!
+        return (TDValue.type(ty), tyTok)
+      }
+    })
+  }
+
+  private func expect(_ t: Token, _ expected: Token) {
+    if t != expected {
+      fatalError("Unexpected token encountered: expected \(expected), found \(t)")
+    }
+  }
+
+  private func expectIdentifier(_ tok: Token) -> String {
+    switch tok {
+    case let .identifier(s): return s
+    default: fatalError("expected ident, found \(tok)")
+    }
+  }
+}
+
+indirect enum LLVMType : Equatable {
+  enum MatchStyle {
+    case direct, extend, truncate, sameWidth, pointersToElem, pointerToElt
+  }
+
+  case void
+  case any
+  case int(Optional<Int>)
+  case float(Optional<Int>)
+  case fixedPoint(Int)
+  case pointer(Optional<LLVMType>)
+
+  case vector(Optional<(Int, LLVMType)>)
+  case metadata
+  case token
+  case vararg
+  case descriptor
+  case x86MMX
+  case mips(LLVMType)
+
+  case matchType(Int, MatchStyle)
+  case matchedType(Int, LLVMType)
+
+  static func sizedInt(_ x: Int) -> LLVMType { return LLVMType.int(.some(x)) }
+  static func sizedFloat(_ x: Int) -> LLVMType { return LLVMType.float(.some(x)) }
+  static func anyPtr(_ ty: LLVMType) -> LLVMType { return LLVMType.pointer(.some(ty)) }
+
+  var llvmName : String {
+    switch self {
+    case let .int(.some(w)):
+      return "i\(w)"
+    case let .float(.some(w)):
+      return "f\(w)"
+    case let .pointer(.some(w)):
+      return "p0\(w.llvmName)"
+    case let .vector(.some(w, ty)) where w != -1:
+      return "v\(w)\(ty.llvmName)"
+    case .matchedType(_, _),
+         .vector(_),
+         .metadata,
+         .vararg,
+         .token,
+         .descriptor,
+         .any,
+         .void:
+      return ""
+    default:
+      fatalError()
+    }
+  }
+
+  static func == (lhs : LLVMType, rhs : LLVMType) -> Bool {
+    switch (lhs, rhs) {
+    case (.void, .void): return true
+    case (.any, .any): return true
+    case let (.int(l), .int(r)): return l == r
+    case let (.float(l), .float(r)): return l == r
+    case let (.fixedPoint(l), .fixedPoint(r)): return l == r
+    case let (.pointer(l), .pointer(r)): return l == r
+    case let (.vector(.some(lw, lt)), .vector(.some(rw, rt))): return lw == rw && lt == rt
+    case (.vector(.none), .vector(.none)): return true
+    case (.metadata, .metadata): return true
+    case (.token, .token): return true
+    case (.vararg, .vararg): return true
+    case (.descriptor, .descriptor): return true
+    case (.x86MMX, .x86MMX): return true
+    case let (.mips(l), .mips(r)): return l == r
+    case let (.matchType(l, s1), .matchType(r, s2)): return l == r && s1 == s2
+    case let (.matchedType(l, _), .matchedType(r, _)): return l == r
+    default: return false
+    }
+  }
+}
+
+extension Character {
+  fileprivate var isDigit : Bool {
+    let utf8Value = self.utf8CodePoint
+    return isdigit(Int32(utf8Value)) != 0
+  }
+}
+
+func internalizeType(_ s: String) -> Optional<LLVMType> {
+  switch s {
+  case "float": return .some(LLVMType.sizedFloat(32))
+  case "double": return .some(LLVMType.sizedFloat(64))
+  case "anyvector": return .some(LLVMType.vector(.none))
+  case "anyfloat": return .some(LLVMType.float(.none))
+  case "anyint": return .some(LLVMType.int(.none))
+  case "anyptr": return .some(LLVMType.pointer(.none))
+  case "any": return .some(LLVMType.any)
+  case "ptr": return .some(LLVMType.anyPtr(.sizedInt(8)))
+  case "ptrptr": return .some(LLVMType.anyPtr(.anyPtr(.sizedInt(8))))
+  case "anyi64ptr": return .some(LLVMType.anyPtr(.sizedInt(64)))
+  case "metadata": return .some(LLVMType.metadata)
+  case "token": return .some(LLVMType.token)
+  case "vararg": return .some(LLVMType.vararg)
+  case "descriptor": return .some(LLVMType.descriptor)
+  case "x86mmx": return .some(LLVMType.x86MMX)
+  case "ptrx86mmx": return .some(LLVMType.anyPtr(.x86MMX))
+  default: break
+  }
+  if s.hasPrefix("i") {
+    return Int(String(s.dropFirst())).map(LLVMType.sizedInt)
+  } else if s.hasPrefix("f") {
+    return Int(String(s.dropFirst())).map(LLVMType.sizedFloat)
+  } else if s.hasPrefix("q") {
+    return Int(String(s.dropFirst())).map(LLVMType.fixedPoint)
+  } else if s.hasPrefix("v") {
+    let vecLen = 1 + s.dropFirst().split(whereSeparator: { d in !d.isDigit }).first!.count
+    return Int(s[s.index(after: s.startIndex)...s.index(s.startIndex, offsetBy: vecLen)]).map({ n in
+      return internalizeType(String(s[s.index(s.startIndex, offsetBy: vecLen)...])).map({ t in LLVMType.vector(.some((n, t))) })
+    })!
+  } else {
+    print("while internalizing types, encountered undefined type name: \(s)");
+    return nil
+  }
+}
+
+extension LLVMType {
+  init?(interning s: String) {
+    let str: String
+    if s.hasPrefix("mips_") && s.hasSuffix("_ty") {
+      str = String(s[s.index(s.startIndex, offsetBy: "mips_".count)..<s.index(s.startIndex, offsetBy: s.count - "_ty".count)])
+    } else {
+      str = String(s[s.index(s.startIndex, offsetBy: "llvm_".count)..<s.index(s.startIndex, offsetBy: s.count - "_ty".count)])
+    }
+
+    guard let internTy = internalizeType(str) ?? internalizeType(s) else {
+      return nil
+    }
+    self = internTy
+  }
+}
+
+extension LLVMType {
+  init?(_ t: TDType) {
+    guard !t.args.isEmpty else {
+      guard let ty = LLVMType(interning: t.name) else {
+        return nil
+      }
+      self = ty
+      return
+    }
+
+    if t.name == "LLVMAnyPointerType", case let TDValue.type(t) = t.args[0] {
+      guard let anyPtrTy = LLVMType(t).map(LLVMType.anyPtr) else {
+        return nil
+      }
+      self = anyPtrTy
+      return
+    }
+
+    if t.name == "LLVMVectorSameWidth", case let TDValue.type(t) = t.args[1] {
+      guard let sameVecTy = LLVMType(t).map({LLVMType.vector(.some((-1, $0)))}) else {
+        return nil
+      }
+      self = sameVecTy
+      return
+    }
+
+    let styleo = { () -> MatchStyle? in
+      switch t.name {
+      case "LLVMMatchType":
+        return MatchStyle.direct
+      case "LLVMExtendedType":
+        return MatchStyle.extend
+      case "LLVMTruncatedType":
+        return MatchStyle.truncate
+      case "LLVMVectorOfPointersToElt", "LLVMVectorOfAnyPointersToElt":
+        return MatchStyle.pointersToElem
+      case "LLVMPointerToElt":
+        return MatchStyle.pointerToElt
+      default:
+        return nil
+      }
+    }()
+
+    let n = { () -> Int? in
+      switch t.args[0] {
+      case let TDValue.int(n): return n
+      default: return nil
+      }
+    }()
+
+    guard let m = n, let style = styleo else {
+      return nil
+    }
+
+    self = LLVMType.matchType(m, style)
+  }
+}
+
+enum Arch : String {
+  case Global = "Global"
+
+  case AMDGPU = "AMDGPU"
+  case Aarch64 = "aarch64"
+  case Arm = "arm"
+  case Cuda = "cuda"
+  case Hexagon = "hexagon"
+  case Mips = "mips"
+  case Nvvm = "nvvm"
+  case Ppc = "ppc"
+  case Ptx = "ptx"
+  case R600 = "r600"
+  case X86 = "x86"
+  case Xcore = "xcore"
+}
+
+struct Intrinsic {
+  enum Stop : Error { case iter }
+
+  let arch: Arch
+  let name: String
+  let gccName: Optional<String>
+  let llvmName: Optional<String>
+  let parameterTypes: Array<LLVMType>
+  let returnTypes: Array<LLVMType>
+
+
+  static func fromAST(_ d: RecordDefinition, with lexRE: NSRegularExpression) -> Optional<Intrinsic> {
+    if !d.name.hasPrefix("int_") { return nil }
+    let strBuf = d.name
+    let string = lexRE.matches(in: strBuf, range: NSRange(location: 0, length: strBuf.utf8.count))[0]
+    let r = string.range
+    let arch = Arch(rawValue: String(strBuf[
+      Range<String.Index>(
+        uncheckedBounds: (
+          strBuf.index(strBuf.startIndex, offsetBy: r.location),
+          strBuf.index(strBuf.startIndex, offsetBy: NSMaxRange(r))
+        )
+    )]))
+
+    var gcc_name : String? = nil;
+    var llvm_name : String? = nil;
+    var params: Array<LLVMType> = [LLVMType]()
+    var rets: Array<LLVMType> = [LLVMType]()
+    for sup in d.baseClassList {
+      switch sup.name {
+      case "GCCBuiltin":
+        switch sup.args[0] {
+        case TDValue.string(let s):
+          if !s.isEmpty {
+            gcc_name = .some(s)
+          }
+        default:
+          return nil
+        }
+
+      case "Intrinsic":
+        switch sup.args[0] {
+        case TDValue.list(let ret_):
+          rets = (try? ret_.map({ v in
+            switch v {
+            case TDValue.type(let t):
+              guard let lt = LLVMType(t) else {
+                throw Stop.iter
+              }
+              return lt
+            default:
+              throw Stop.iter
+            }
+          })) ?? []
+        default:
+          return nil
+        }
+
+        switch sup.args[1] {
+        case TDValue.list(let params_):
+          params = (try? params_.map({ v in
+            switch v {
+            case TDValue.type(let t):
+              guard let lt = LLVMType(t) else {
+                _ = LLVMType(t)
+                throw Stop.iter
+              }
+              return lt
+            default:
+              throw Stop.iter
+            }
+          })) ?? []
+        default:
+          return nil
+        }
+
+        switch sup.args[3] {
+        case TDValue.string(let s):
+          if !s.isEmpty {
+            llvm_name = .some(s)
+          }
+        default:
+          return nil
+        }
+
+      default:
+        continue
+      }
+    }
+
+    return .some(Intrinsic(
+      arch: arch ?? Arch.Global,
+      name: d.name,
+      gccName: gcc_name,
+      llvmName: llvm_name,
+      parameterTypes: params,
+      returnTypes: rets.isEmpty ? [LLVMType.void] : rets
+    ))
+  }
+}
+
+extension Intrinsic {
+  func signatures() -> [(String, [LLVMType], LLVMType)] {
+    var sigs = [(String, [LLVMType], LLVMType)]()
+    let tys = self.returnTypes + self.parameterTypes
+
+    func permute(_ ty : LLVMType) -> [LLVMType] {
+      switch ty {
+      case .pointer(.none):
+        return [.pointer(.some(.int(8)))]
+      case let .pointer(.some(i)):
+        return permute(i).map({ LLVMType.pointer(.some($0)) })
+      case .int(.none):
+        return [.sizedInt(8), .sizedInt(16), .sizedInt(32), .sizedInt(64)]
+      case let .int(.some(w)):
+        return [.int(w)]
+      case .float(.none):
+        return [.sizedFloat(16), .sizedFloat(32), .sizedFloat(64), .sizedFloat(80), .sizedFloat(128)]
+      case let .float(.some(w)):
+        return [.float(w)]
+      case .void:
+        return [.void]
+      case .metadata:
+        return [.metadata]
+      case .vararg:
+        return [.vararg]
+      case .token:
+        return [.token]
+      case .descriptor:
+        return [.descriptor]
+      case .any:
+        return [.any]
+      case let .matchType(n, .pointerToElt):
+        return [.matchedType(n, LLVMType.anyPtr(tys[n]))]
+      case let .matchType(n, .pointersToElem):
+        return [.matchedType(n, LLVMType.vector(.some((-1, LLVMType.anyPtr(tys[n])))))]
+      case let .matchType(n, _):
+        return [.matchedType(n, tys[n])]
+        // N.B. Do not expand the overload set here.  There are simply too many
+      // permutations to cover.  Dynamically generate these instead.
+      case .vector(_):
+        return [ty]
+      default:
+        fatalError()
+      }
+    }
+
+    let baseName : String
+    if let lName = self.llvmName?.trimmingCharacters(in: CharacterSet(charactersIn: "\"")), !lName.isEmpty {
+      baseName = lName
+    } else if self.name == "int_ssa_copy" {
+      // HACK: int_ssa_copy is missing its LLVM Name and bucks the naming
+      // convention by having the proper name "llvm.ssa_copy".
+      baseName = "llvm." + String(self.name.dropFirst("int_".count))
+    } else {
+      baseName = "llvm." + String(self.name.dropFirst("int_".count)).replacingOccurrences(of: "_", with: ".")
+    }
+
+    let sigMatrix = tys.map(permute)
+
+    guard sigMatrix.reduce(false, { (acc, arr) in
+      return acc || arr.count > 1
+    }) else {
+      let retTy = sigMatrix.first!.first!
+      let paramTys = [LLVMType](sigMatrix.dropFirst().joined())
+      return [(baseName, paramTys, retTy)]
+    }
+
+    var overloadMatrix = [[LLVMType]]()
+    var sawOverload = false
+    for i in 0..<sigMatrix.count {
+      let parameters = sigMatrix[i]
+      assert(!parameters.isEmpty)
+
+      // If we're out of overloads to process next, drop it.  The signature
+      // extends only as far as the first overloaded parameter.
+      if sawOverload && parameters.count < 2 {
+        break
+      }
+
+      guard parameters.count > 1 else {
+        // If the transposed matrix is empty, stick the first parameter in.
+        guard !overloadMatrix.isEmpty else {
+          overloadMatrix.append([parameters[0]])
+          continue
+        }
+
+        // Just append the parameter
+        for j in 0..<overloadMatrix.count {
+          overloadMatrix[j].append(parameters[0])
+        }
+
+        continue
+      }
+
+      // Only stop permuting if we encounter an overloaded parameter.
+      sawOverload = (i != 0)
+
+      guard !overloadMatrix.isEmpty else {
+        for p in parameters {
+          overloadMatrix.append([p])
+        }
+        continue
+      }
+
+      let matrixCpy = overloadMatrix
+      for _ in 1..<parameters.count {
+        overloadMatrix.append(contentsOf: matrixCpy)
+      }
+
+      assert(overloadMatrix.count % parameters.count == 0)
+      for j in 0..<overloadMatrix.count {
+        let paramOverload = parameters[j % parameters.count]
+        overloadMatrix[j].append(paramOverload)
+      }
+    }
+
+    // Verify all the overloads recieved the same number of parameters.
+    assert({
+      let checkCnt = overloadMatrix[0].count
+      return overloadMatrix.reduce(true) { (acc, arr) in acc && arr.count == checkCnt }
+    }())
+
+    var seenSelectors = Set<String>()
+    for initialList in overloadMatrix {
+      // Re-process matched types.
+      let paramList = initialList.map { (p) -> LLVMType in
+        if case let .matchedType(n, _) = p {
+          return LLVMType.matchedType(n, initialList[n])
+        }
+        return p
+      }
+      let retTy = paramList.first!
+      let selector = ([baseName] + paramList.compactMap({ $0.llvmName.isEmpty ? nil : $0.llvmName })).joined(separator: ".")
+      guard seenSelectors.insert(selector).inserted else {
+        continue
+      }
+      sigs.append((selector, [LLVMType](paramList.dropFirst()), retTy))
+    }
+
+    return sigs
+  }
+}
+
+func parse(s: String, root: String) -> Array<Object> {
+  guard let lexRE = try? NSRegularExpression(pattern: "[A-Za-z0-9_]+") else {
+    fatalError()
+  }
+  var p = Parser(
+    tokens: tokenize(s, with: lexRE).makeIterator(),
+    root: root
+  )
+  return p.parseTableGen()
+}
+
+func formFunctionTypeString(_ params: [LLVMType], _ retTy: LLVMType) -> String {
+  func translateAType(_ ty : LLVMType) -> String {
+    switch ty {
+    case .float(.some(16)):
+      return "FloatType.half"
+    case .float(.some(32)):
+      return "FloatType.float"
+    case .float(.some(64)):
+      return "FloatType.double"
+    case .float(.some(80)):
+      return "FloatType.x86FP80"
+    case .float(.some(128)):
+      return "FloatType.ppcFP128"
+    case .int(.some(let w)):
+      return "IntType(width: \(w))"
+    case .x86MMX:
+      return "X86MMXType()"
+    case .matchedType(_, let ty):
+      return translateAType(ty)
+    case .pointer(.some(let ty)):
+      return "PointerType(pointee: \(translateAType(ty)))"
+    case .pointer(.none):
+      return "PointerType(pointee: IntType.int8)"
+    case .vector(.none):
+      return "VectorType(elementType: IntrinsicSubstitutionMarker(), count: -1)"
+    case .vector(.some(let size, let ty)) where size == -1:
+      return "VectorType(elementType: \(translateAType(ty)), count: -1)"
+    case .vector(.some(let size, let ty)):
+      return "VectorType(elementType: \(translateAType(ty)), count: \(size))"
+    case .metadata:
+      return "MetadataType()"
+    case .token:
+      return "TokenType()"
+    case .void:
+      return "VoidType()"
+    case .descriptor:
+      return "PointerType(pointee: StructType(elementTypes: []))"
+    case .any:
+      return "IntrinsicSubstitutionMarker()"
+    case .vararg:
+      return ""
+    default:
+      fatalError("\(ty)")
+    }
+  }
+  let paramTys = params.map(translateAType)
+  let paramTyStr : String
+  let isVariadic : String
+  if let last = paramTys.last, last.isEmpty {
+    paramTyStr = paramTys.dropLast().joined(separator: ", ")
+    isVariadic = "true"
+  } else {
+    paramTyStr = paramTys.joined(separator: ", ")
+    isVariadic = "false"
+  }
+  let retTyStr = translateAType(retTy)
+  return "FunctionType(argTypes: [\(paramTyStr)], returnType: \(retTyStr), isVarArg: \(isVariadic))"
+}
+
+func run() {
+  guard CommandLine.arguments.count > 1 else {
+    print("usage: intrinsics-gen td-file ...")
+    return
+  }
+
+  let args = CommandLine.arguments.dropFirst()
+  guard args.reduce(true, { (acc, s) in s.hasSuffix(".td") && acc }) else {
+    print("fatal: all arguments must be '.td' files")
+    return
+  }
+
+  let fileUrls = args.compactMap(URL.init(fileURLWithPath:))
+  guard fileUrls.count == args.count else {
+    print("fatal: unable to locate all td files: \(args.joined(separator: ", "))")
+    return
+  }
+
+  var intrinsicMap = Dictionary<Arch, [Intrinsic]>();
+  for url in fileUrls {
+    guard let s = try? String(contentsOf: url, encoding: .utf8) else {
+      print("fatal: unable to read file at path: \(url.absoluteString)")
+      return
+    }
+
+    let ast = parse(s: s, root: "")
+    let (classes, defs) = extractDefinitions(ast)
+
+    var classNames = Dictionary<String, ClassDecl>()
+    for c in classes {
+      guard classNames.updateValue(c, forKey: c.name) == nil else {
+        print("fatal: multiple definitions of class '\(c.name)' found")
+        return
+      }
+    }
+
+    resolveClasses(defs, classNames)
+
+    guard let lexRE = try? NSRegularExpression(pattern: "^int_([^_]*)") else {
+      fatalError()
+    }
+
+    for d in defs {
+      let intr : Intrinsic
+      switch Intrinsic.fromAST(d, with: lexRE) {
+      case .none where !d.name.hasPrefix("int_"):
+        continue
+      case .none:
+        fatalError("failed to parse: \(d)")
+      case let .some(intr2):
+        intr = intr2
+      }
+
+      if intrinsicMap[intr.arch] != nil {
+        intrinsicMap[intr.arch]!.append(intr)
+      } else {
+        intrinsicMap[intr.arch] = [intr]
+      }
+    }
+  }
+
+  var fileStructure = [String]()
+  fileStructure.append("""
+  // THIS FILE IS PROGRAMMATICALLY GENERATED!
+  // DO NOT EDIT IT BY HAND!
+  //
+  // ALWAYS RUN intrinsics-gen AGAINST THE LATEST Intrinsics.td
+
+  import LLVM
+
+  """)
+  for (arch, instrs) in intrinsicMap {
+    print("Dumping arch: '\(arch)Intrinsics'...")
+    var enums = [String]()
+    var singularCaseMap = [(String, String)]()
+    fileStructure.append("public enum \(arch.rawValue)Intrinsics: String, LLVMIntrinsic {")
+    for intr in instrs {
+      let sigs = intr.signatures()
+      assert(!sigs.isEmpty)
+
+      if sigs.count != 1 {
+        var enumStr = "  public enum \(intr.name): String, LLVMOverloadedIntrinsic {"
+        var caseMap = [(String, String)]()
+        for (c, ps, rs) in sigs {
+          let caseName = c.replacingOccurrences(of: ".", with: "_")
+          caseMap.append((caseName, formFunctionTypeString(ps, rs)))
+          enumStr.append("\n    case \(caseName) = \"\(c)\"")
+        }
+
+        enumStr.append("\n\n    public var llvmSelector: String { return self.rawValue }")
+        enumStr.append("\n\n    public var signature: FunctionType {")
+        enumStr.append("\n      switch self {")
+        for (caseName, fnTyStr) in caseMap {
+          enumStr.append("\n      case .\(caseName): return \(fnTyStr)")
+        }
+        enumStr.append("\n      }")
+        enumStr.append("\n    }")
+        enumStr.append("\n\n    public static var overloadSet: [LLVMIntrinsic] {")
+        enumStr.append("\n      return [")
+        for (caseName, _) in caseMap {
+          enumStr.append("\n        \(intr.name).\(caseName),")
+        }
+        enumStr.append("\n      ]")
+        enumStr.append("\n    }")
+
+        enumStr.append("\n  }\n")
+
+        enums.append(enumStr)
+      } else {
+        let caseName = sigs[0].0.replacingOccurrences(of: ".", with: "_")
+        singularCaseMap.append((caseName, formFunctionTypeString(sigs[0].1, sigs[0].2)))
+        fileStructure.append("\n  case \(caseName) = \"\(sigs[0].0)\"")
+      }
+    }
+
+    fileStructure.append("\n\n  public var llvmSelector: String { return self.rawValue }")
+    fileStructure.append("\n\n  public var signature: FunctionType {")
+    fileStructure.append("\n    switch self {")
+    for (caseName, fnTyStr) in singularCaseMap {
+      fileStructure.append("\n    case .\(caseName): return \(fnTyStr)")
+    }
+    fileStructure.append("\n    }")
+    fileStructure.append("\n  }\n\n")
+    fileStructure.append(contentsOf: enums)
+    fileStructure.append("\n}\n\n")
+
+    //    dump(enums)
+    //    dump(singularCases)
+  }
+
+  let dir = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+  let writeURL = dir.appendingPathComponent("Sources/LLVMIntrinsics/IntrinsicsDef.swift")
+  print("Done!  Wrote to \(writeURL)")
+  // Write out the swift file
+  try! fileStructure.joined().write(to: writeURL, atomically: false, encoding: .utf8)
+}
+
+run()
+
+


### PR DESCRIPTION
The infrastructure to generate `Call`s is all here in this patch.  However, the interface makes no guarantees of type safety, and LLVM overloads its intrinsics, so we have a real chance to provide just the subset of commented-out calls, do some type checks, and a little introspection to dispatch to the right intrinsic overload.

<strike>Basically, what should the typesafe API look like, if any?</strike>