### PR TITLE
Ensure LLVM is initialized for TargetMachine use

### DIFF
--- a/Sources/LLVM/Initialization.swift
+++ b/Sources/LLVM/Initialization.swift
@@ -2,10 +2,10 @@
 import cllvm
 #endif
 
-/// Lazy static initializer that calls LLVM initialization functions only once.
-let llvmInitializer: Void = {
-  initializeLLVM()
-}()
+/// initializer that calls LLVM initialization functions only once.
+public func initializeLLVM() {
+  _ = llvmInitializer
+}
 
 /// Calls all the LLVM functions to initialize:
 ///
@@ -15,7 +15,7 @@ let llvmInitializer: Void = {
 /// - ASM Parsers
 /// - Target MCs
 /// - Disassemblers
-private func initializeLLVM() {
+let llvmInitializer: Void = {
   LLVMInitializeAllTargets()
   LLVMInitializeAllTargetInfos()
 
@@ -25,4 +25,5 @@ private func initializeLLVM() {
   LLVMInitializeAllTargetMCs()
 
   LLVMInitializeAllDisassemblers()
-}
+}()
+

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -53,9 +53,8 @@ public final class Module: CustomStringConvertible {
   ///   context is provided, one will be inferred.
   public init(name: String, context: Context? = nil) {
 
-    // Ensure the LLVM initializer is called when the first module
-    // is created
-    _ = llvmInitializer
+    // Ensure the LLVM initializer is called when the first module is created
+    initializeLLVM()
 
     if let context = context {
       llvm = LLVMModuleCreateWithNameInContext(name, context.llvm)

--- a/Sources/LLVM/TargetMachine.swift
+++ b/Sources/LLVM/TargetMachine.swift
@@ -136,6 +136,10 @@ public class TargetMachine {
   public init(triple: String? = nil, cpu: String = "", features: String = "",
               optLevel: CodeGenOptLevel = .default, relocMode: RelocMode = .default,
               codeModel: CodeModel = .default) throws {
+
+    // Ensure the LLVM initializer is called when the first module is created
+    initializeLLVM()
+
     self.triple = triple ?? String(cString: LLVMGetDefaultTargetTriple()!)
     var target: LLVMTargetRef?
     var error: UnsafeMutablePointer<Int8>?


### PR DESCRIPTION
This PR:
- Initializes LLVM in TargetMachine's pubic initialize as it done in Module.
- Also exposes the Initialize call to client code to allow the decision of when to perform initialization to be made by the client without needing to initialize any dummy values