### PR TITLE
Type contexts

### DIFF
--- a/Sources/LLVM/ArrayType.swift
+++ b/Sources/LLVM/ArrayType.swift
@@ -12,6 +12,7 @@ public struct ArrayType: IRType {
   public let count: Int
 
   /// Creates an array type from an underlying element type and count.
+  /// - note: The context of this type is taken from it's `elementType`
   public init(elementType: IRType, count: Int) {
     self.elementType = elementType
     self.count = count

--- a/Sources/LLVM/FloatType.swift
+++ b/Sources/LLVM/FloatType.swift
@@ -38,17 +38,17 @@ public struct FloatType: IRType {
   }
 
   /// 16-bit floating point value in the global context
-  static let half = FloatType(kind: .half)
+  public static let half = FloatType(kind: .half)
   /// 32-bit floating point value in the global context
-  static let float = FloatType(kind: .float)
+  public static let float = FloatType(kind: .float)
   /// 64-bit floating point value in the global context
-  static let double = FloatType(kind: .double)
+  public static let double = FloatType(kind: .double)
   /// 80-bit floating point value (X87) in the global context
-  static let x86FP80 = FloatType(kind: .x86FP80)
+  public static let x86FP80 = FloatType(kind: .x86FP80)
   /// 128-bit floating point value (112-bit mantissa) in the global context
-  static let fp128 = FloatType(kind: .fp128)
+  public static let fp128 = FloatType(kind: .fp128)
   /// 128-bit floating point value (two 64-bits) in the global context
-  static let ppcFP128 = FloatType(kind: .ppcFP128)
+  public static let ppcFP128 = FloatType(kind: .ppcFP128)
 
   /// Creates a constant floating value of this type from a Swift `Double` value.
   public func constant(_ value: Double) -> Constant<Floating> {

--- a/Sources/LLVM/FloatType.swift
+++ b/Sources/LLVM/FloatType.swift
@@ -9,7 +9,7 @@ public struct FloatType: IRType {
   /// The kind of floating point type this is
   public var kind: Kind
 
-  /// Returns the context associated with this module.
+  /// Returns the context associated with this type.
   public let context: Context
 
   /// Creates a float type of a particular kind

--- a/Sources/LLVM/FloatType.swift
+++ b/Sources/LLVM/FloatType.swift
@@ -4,19 +4,51 @@ import cllvm
 
 /// `FloatType` enumerates representations of a floating value of a particular
 /// bit width and semantics.
-public enum FloatType: IRType {
-  /// 16-bit floating point value
-  case half
-  /// 32-bit floating point value
-  case float
-  /// 64-bit floating point value
-  case double
-  /// 80-bit floating point value (X87)
-  case x86FP80
-  /// 128-bit floating point value (112-bit mantissa)
-  case fp128
-  /// 128-bit floating point value (two 64-bits)
-  case ppcFP128
+public struct FloatType: IRType {
+
+  /// The kind of floating point type this is
+  public var kind: Kind
+
+  /// Returns the context associated with this module.
+  public let context: Context?
+
+  /// Creates a float type of a particular kind
+  ///
+  /// - parameter kind: The kind of floating point type to create
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(kind: Kind, in context: Context? = nil) {
+    self.kind = kind
+    self.context = context
+  }
+
+  public enum Kind {
+    /// 16-bit floating point value
+    case half
+    /// 32-bit floating point value
+    case float
+    /// 64-bit floating point value
+    case double
+    /// 80-bit floating point value (X87)
+    case x86FP80
+    /// 128-bit floating point value (112-bit mantissa)
+    case fp128
+    /// 128-bit floating point value (two 64-bits)
+    case ppcFP128
+  }
+
+  /// 16-bit floating point value in the global context
+  static let half = FloatType(kind: .half)
+  /// 32-bit floating point value in the global context
+  static let float = FloatType(kind: .float)
+  /// 64-bit floating point value in the global context
+  static let double = FloatType(kind: .double)
+  /// 80-bit floating point value (X87) in the global context
+  static let x86FP80 = FloatType(kind: .x86FP80)
+  /// 128-bit floating point value (112-bit mantissa) in the global context
+  static let fp128 = FloatType(kind: .fp128)
+  /// 128-bit floating point value (two 64-bits) in the global context
+  static let ppcFP128 = FloatType(kind: .ppcFP128)
 
   /// Creates a constant floating value of this type from a Swift `Double` value.
   public func constant(_ value: Double) -> Constant<Floating> {
@@ -25,7 +57,17 @@ public enum FloatType: IRType {
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    switch self {
+    if let context = context {
+        switch kind {
+        case .half: return LLVMHalfTypeInContext(context.llvm)
+        case .float: return LLVMFloatTypeInContext(context.llvm)
+        case .double: return LLVMDoubleTypeInContext(context.llvm)
+        case .x86FP80: return LLVMX86FP80TypeInContext(context.llvm)
+        case .fp128: return LLVMFP128TypeInContext(context.llvm)
+        case .ppcFP128: return LLVMPPCFP128TypeInContext(context.llvm)
+        }
+    }
+    switch kind {
     case .half: return LLVMHalfType()
     case .float: return LLVMFloatType()
     case .double: return LLVMDoubleType()

--- a/Sources/LLVM/FloatType.swift
+++ b/Sources/LLVM/FloatType.swift
@@ -10,14 +10,14 @@ public struct FloatType: IRType {
   public var kind: Kind
 
   /// Returns the context associated with this module.
-  public let context: Context?
+  public let context: Context
 
   /// Creates a float type of a particular kind
   ///
   /// - parameter kind: The kind of floating point type to create
   /// - parameter context: The context to create this type in
   /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
-  public init(kind: Kind, in context: Context? = nil) {
+  public init(kind: Kind, in context: Context = Context.global) {
     self.kind = kind
     self.context = context
   }
@@ -57,23 +57,13 @@ public struct FloatType: IRType {
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    if let context = context {
-        switch kind {
-        case .half: return LLVMHalfTypeInContext(context.llvm)
-        case .float: return LLVMFloatTypeInContext(context.llvm)
-        case .double: return LLVMDoubleTypeInContext(context.llvm)
-        case .x86FP80: return LLVMX86FP80TypeInContext(context.llvm)
-        case .fp128: return LLVMFP128TypeInContext(context.llvm)
-        case .ppcFP128: return LLVMPPCFP128TypeInContext(context.llvm)
-        }
-    }
     switch kind {
-    case .half: return LLVMHalfType()
-    case .float: return LLVMFloatType()
-    case .double: return LLVMDoubleType()
-    case .x86FP80: return LLVMX86FP80Type()
-    case .fp128: return LLVMFP128Type()
-    case .ppcFP128: return LLVMPPCFP128Type()
+    case .half: return LLVMHalfTypeInContext(context.llvm)
+    case .float: return LLVMFloatTypeInContext(context.llvm)
+    case .double: return LLVMDoubleTypeInContext(context.llvm)
+    case .x86FP80: return LLVMX86FP80TypeInContext(context.llvm)
+    case .fp128: return LLVMFP128TypeInContext(context.llvm)
+    case .ppcFP128: return LLVMPPCFP128TypeInContext(context.llvm)
     }
   }
 }

--- a/Sources/LLVM/FunctionType.swift
+++ b/Sources/LLVM/FunctionType.swift
@@ -20,6 +20,7 @@ public struct FunctionType: IRType {
   /// - parameter returnType: The return type of the function type.
   /// - parameter isVarArg: Indicates whether this function type is variadic.
   ///   Defaults to `false`.
+  /// - note: The context of this type is taken from it's `returnType`
   public init(argTypes: [IRType], returnType: IRType, isVarArg: Bool = false) {
     self.argTypes = argTypes
     self.returnType = returnType

--- a/Sources/LLVM/IRType.swift
+++ b/Sources/LLVM/IRType.swift
@@ -31,7 +31,7 @@ public extension IRType {
   }
 
   /// Returns the context associated with this type
-  public func context() -> Context {
+  public var context: Context {
     return Context(llvm: LLVMGetTypeContext(asLLVM()))
   }
 }

--- a/Sources/LLVM/IRType.swift
+++ b/Sources/LLVM/IRType.swift
@@ -29,6 +29,11 @@ public extension IRType {
   public func constPointerNull() -> IRValue {
     return LLVMConstPointerNull(asLLVM())
   }
+
+  /// Returns the context associated with this type
+  public func context() -> Context {
+    return Context(llvm: LLVMGetTypeContext(asLLVM()))
+  }
 }
 
 internal func convertType(_ type: LLVMTypeRef) -> IRType {

--- a/Sources/LLVM/IRType.swift
+++ b/Sources/LLVM/IRType.swift
@@ -37,20 +37,19 @@ public extension IRType {
 }
 
 internal func convertType(_ type: LLVMTypeRef) -> IRType {
+  let context = Context(llvm: LLVMGetTypeContext(type))
   switch LLVMGetTypeKind(type) {
-  case LLVMVoidTypeKind:
-    return VoidType()
-  case LLVMHalfTypeKind:
-    return FloatType.half
-  case LLVMFloatTypeKind: return FloatType.float
-  case LLVMDoubleTypeKind: return FloatType.double
-  case LLVMX86_FP80TypeKind: return FloatType.x86FP80
-  case LLVMFP128TypeKind: return FloatType.fp128
-  case LLVMPPC_FP128TypeKind: return FloatType.fp128
-  case LLVMLabelTypeKind: return LabelType()
+  case LLVMVoidTypeKind: return VoidType(in: context)
+  case LLVMFloatTypeKind: return FloatType(kind: .float, in: context)
+  case LLVMHalfTypeKind: return FloatType(kind: .half, in: context)
+  case LLVMDoubleTypeKind: return FloatType(kind: .double, in: context)
+  case LLVMX86_FP80TypeKind: return FloatType(kind: .x86FP80, in: context)
+  case LLVMFP128TypeKind: return FloatType(kind: .fp128, in: context)
+  case LLVMPPC_FP128TypeKind: return FloatType(kind: .fp128, in: context)
+  case LLVMLabelTypeKind: return LabelType(in: context)
   case LLVMIntegerTypeKind:
     let width = LLVMGetIntTypeWidth(type)
-    return IntType(width: Int(width))
+    return IntType(width: Int(width), in: context)
   case LLVMFunctionTypeKind:
     var params = [IRType]()
     let count = Int(LLVMCountParamTypes(type))
@@ -81,7 +80,7 @@ internal func convertType(_ type: LLVMTypeRef) -> IRType {
   case LLVMMetadataTypeKind:
     return MetadataType(llvm: type)
   case LLVMX86_MMXTypeKind:
-    return X86MMXType()
+    return X86MMXType(in: context)
   case LLVMTokenTypeKind:
     return TokenType(llvm: type)
   default: fatalError("unknown type kind for type \(type)")

--- a/Sources/LLVM/IntType.swift
+++ b/Sources/LLVM/IntType.swift
@@ -11,7 +11,7 @@ public struct IntType: IRType {
   /// Retrieves the bit width of this integer type.
   public let width: Int
 
-  /// Returns the context associated with this module.
+  /// Returns the context associated with this type.
   public let context: Context
 
   /// Creates an integer type with the specified bit width.

--- a/Sources/LLVM/IntType.swift
+++ b/Sources/LLVM/IntType.swift
@@ -12,14 +12,14 @@ public struct IntType: IRType {
   public let width: Int
 
   /// Returns the context associated with this module.
-  public let context: Context?
+  public let context: Context
 
   /// Creates an integer type with the specified bit width.
   ///
   /// - parameter width: The width in bits of the integer type
   /// - parameter context: The context to create this type in
   /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
-  public init(width: Int, in context: Context? = nil) {
+  public init(width: Int, in context: Context = Context.global) {
     self.width = width
     self.context = context
   }
@@ -78,9 +78,6 @@ public struct IntType: IRType {
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    if let context = context {
-        return LLVMIntTypeInContext(context.llvm, UInt32(width))
-    }
-    return LLVMIntType(UInt32(width))
+    return LLVMIntTypeInContext(context.llvm, UInt32(width))
   }
 }

--- a/Sources/LLVM/IntType.swift
+++ b/Sources/LLVM/IntType.swift
@@ -11,8 +11,18 @@ public struct IntType: IRType {
   /// Retrieves the bit width of this integer type.
   public let width: Int
 
+  /// Returns the context associated with this module.
+  public let context: Context?
+
   /// Creates an integer type with the specified bit width.
-  public init(width: Int) { self.width = width }
+  ///
+  /// - parameter width: The width in bits of the integer type
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(width: Int, in context: Context? = nil) {
+    self.width = width
+    self.context = context
+  }
 
   /// Retrieves the `i1` type.
   public static let int1 = IntType(width: 1)
@@ -68,6 +78,9 @@ public struct IntType: IRType {
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
+    if let context = context {
+        return LLVMIntTypeInContext(context.llvm, UInt32(width))
+    }
     return LLVMIntType(UInt32(width))
   }
 }

--- a/Sources/LLVM/LabelType.swift
+++ b/Sources/LLVM/LabelType.swift
@@ -4,11 +4,23 @@ import cllvm
 
 /// `LabelType` represents code labels.
 public struct LabelType: IRType {
+
+  /// Returns the context associated with this module.
+  public let context: Context?
+
   /// Creates a code label.
-  public init() {}
+  ///
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(context: Context? = nil) {
+      self.context = context
+  }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
+    if let context = context {
+       return LLVMLabelTypeInContext(context.llvm)
+    }
     return LLVMLabelType()
   }
 }

--- a/Sources/LLVM/LabelType.swift
+++ b/Sources/LLVM/LabelType.swift
@@ -6,21 +6,18 @@ import cllvm
 public struct LabelType: IRType {
 
   /// Returns the context associated with this module.
-  public let context: Context?
+  public let context: Context
 
   /// Creates a code label.
   ///
   /// - parameter context: The context to create this type in
   /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
-  public init(in context: Context? = nil) {
+  public init(in context: Context = Context.global) {
       self.context = context
   }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    if let context = context {
-       return LLVMLabelTypeInContext(context.llvm)
-    }
-    return LLVMLabelType()
+   return LLVMLabelTypeInContext(context.llvm)
   }
 }

--- a/Sources/LLVM/LabelType.swift
+++ b/Sources/LLVM/LabelType.swift
@@ -5,7 +5,7 @@ import cllvm
 /// `LabelType` represents code labels.
 public struct LabelType: IRType {
 
-  /// Returns the context associated with this module.
+  /// Returns the context associated with this type.
   public let context: Context
 
   /// Creates a code label.

--- a/Sources/LLVM/LabelType.swift
+++ b/Sources/LLVM/LabelType.swift
@@ -12,7 +12,7 @@ public struct LabelType: IRType {
   ///
   /// - parameter context: The context to create this type in
   /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
-  public init(context: Context? = nil) {
+  public init(in context: Context? = nil) {
       self.context = context
   }
 

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -5,14 +5,28 @@ import cllvm
 /// A `Context` represents execution states for the core LLVM IR system.
 public class Context {
   internal let llvm: LLVMContextRef
+  internal let ownsContext: Bool
 
   /// Retrieves the global context instance.
   public static let global = Context(llvm: LLVMGetGlobalContext()!)
 
-  /// Creates a `Context` object from an `LLVMContextRef` object.
-  public init(llvm: LLVMContextRef) {
-    self.llvm = llvm
+  /// Creates a `Context` object using `LLVMContextCreate`
+  public init() {
+    llvm = LLVMContextCreate()
+    ownsContext = true
   }
+
+  /// Creates a `Context` object from an `LLVMContextRef` object.
+  public init(llvm: LLVMContextRef, ownsContext: Bool = false) {
+    self.llvm = llvm
+    self.ownsContext = ownsContext
+  }
+
+    deinit {
+        if ownsContext {
+            LLVMContextDispose(llvm)
+        }
+    }
 }
 
 /// Represents the possible errors that can be thrown while interacting with a

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -22,11 +22,11 @@ public class Context {
     self.ownsContext = ownsContext
   }
 
-    deinit {
-        if ownsContext {
-            LLVMContextDispose(llvm)
-        }
+  deinit {
+    if ownsContext {
+      LLVMContextDispose(llvm)
     }
+  }
 }
 
 /// Represents the possible errors that can be thrown while interacting with a

--- a/Sources/LLVM/PointerType.swift
+++ b/Sources/LLVM/PointerType.swift
@@ -23,6 +23,7 @@ public struct PointerType: IRType {
   /// - parameter pointee: The type of the pointed-to object.
   /// - parameter addressSpace: The optional address space where the pointed-to
   ///   object resides.
+  /// - note: The context of this type is taken from it's pointee
   public init(pointee: IRType, addressSpace: Int = 0) {
     // FIXME: This class of invalid reference is not caught by Module.verify(),
     // only `lli`.

--- a/Sources/LLVM/StructType.swift
+++ b/Sources/LLVM/StructType.swift
@@ -37,14 +37,10 @@ public struct StructType: IRType {
   ///   no packing between fields.  Defaults to `false`.
   /// - parameter context: The context to create this type in
   /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
-  public init(elementTypes: [IRType], isPacked: Bool = false, in context: Context? = nil) {
+  public init(elementTypes: [IRType], isPacked: Bool = false, in context: Context = Context.global) {
     var irTypes = elementTypes.map { $0.asLLVM() as Optional }
     self.llvm = irTypes.withUnsafeMutableBufferPointer { buf in
-      if let context = context {
-        return LLVMStructTypeInContext(context.llvm, buf.baseAddress, UInt32(buf.count), isPacked.llvm)
-      } else {
-        return LLVMStructType(buf.baseAddress, UInt32(buf.count), isPacked.llvm)
-      }
+      return LLVMStructTypeInContext(context.llvm, buf.baseAddress, UInt32(buf.count), isPacked.llvm)
     }
   }
 

--- a/Sources/LLVM/StructType.swift
+++ b/Sources/LLVM/StructType.swift
@@ -35,10 +35,16 @@ public struct StructType: IRType {
   /// - parameter elementTypes: A list of types of members of this structure.
   /// - parameter isPacked: Whether or not this structure is 1-byte aligned with
   ///   no packing between fields.  Defaults to `false`.
-  public init(elementTypes: [IRType], isPacked: Bool = false) {
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(elementTypes: [IRType], isPacked: Bool = false, in context: Context? = nil) {
     var irTypes = elementTypes.map { $0.asLLVM() as Optional }
     self.llvm = irTypes.withUnsafeMutableBufferPointer { buf in
-      LLVMStructType(buf.baseAddress, UInt32(buf.count), isPacked.llvm)
+      if let context = context {
+        return LLVMStructTypeInContext(context.llvm, buf.baseAddress, UInt32(buf.count), isPacked.llvm)
+      } else {
+        return LLVMStructType(buf.baseAddress, UInt32(buf.count), isPacked.llvm)
+      }
     }
   }
 

--- a/Sources/LLVM/VectorType.swift
+++ b/Sources/LLVM/VectorType.swift
@@ -16,6 +16,7 @@ public struct VectorType: IRType {
   ///
   /// - parameter elementType: The type of elements of this vector.
   /// - parameter count: The number of elements in this vector.
+  /// - note: The context of this type is taken from it's `elementType`
   public init(elementType: IRType, count: Int) {
     self.elementType = elementType
     self.count = count

--- a/Sources/LLVM/VoidType.swift
+++ b/Sources/LLVM/VoidType.swift
@@ -6,21 +6,18 @@ import cllvm
 public struct VoidType: IRType {
 
   /// Returns the context associated with this module.
-  public let context: Context?
+  public let context: Context
 
   /// Creates an instance of the `Void` type.
   ///
   /// - parameter context: The context to create this type in
   /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
-  public init(in context: Context? = nil) {
+  public init(in context: Context = Context.global) {
     self.context = context
   }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    if let context = context {
-      return LLVMVoidTypeInContext(context.llvm)
-    }
-    return LLVMVoidType()
+    return LLVMVoidTypeInContext(context.llvm)
   }
 }

--- a/Sources/LLVM/VoidType.swift
+++ b/Sources/LLVM/VoidType.swift
@@ -4,11 +4,23 @@ import cllvm
 
 /// The `Void` type represents any value and has no size.
 public struct VoidType: IRType {
+
+  /// Returns the context associated with this module.
+  public let context: Context?
+
   /// Creates an instance of the `Void` type.
-  public init() {}
+  ///
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(in context: Context? = nil) {
+    self.context = context
+  }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
+    if let context = context {
+      return LLVMVoidTypeInContext(context.llvm)
+    }
     return LLVMVoidType()
   }
 }

--- a/Sources/LLVM/VoidType.swift
+++ b/Sources/LLVM/VoidType.swift
@@ -5,7 +5,7 @@ import cllvm
 /// The `Void` type represents any value and has no size.
 public struct VoidType: IRType {
 
-  /// Returns the context associated with this module.
+  /// Returns the context associated with this type.
   public let context: Context
 
   /// Creates an instance of the `Void` type.

--- a/Sources/LLVM/X86MMXType.swift
+++ b/Sources/LLVM/X86MMXType.swift
@@ -10,7 +10,7 @@ import cllvm
 /// type. There are no arrays, vectors or constants of this type.
 public struct X86MMXType: IRType {
 
-  /// Returns the context associated with this module.
+  /// Returns the context associated with this type.
   public let context: Context
 
   /// Creates an `X86MMXType`.

--- a/Sources/LLVM/X86MMXType.swift
+++ b/Sources/LLVM/X86MMXType.swift
@@ -9,11 +9,23 @@ import cllvm
 /// represented as intrinsic or asm calls with arguments and/or results of this
 /// type. There are no arrays, vectors or constants of this type.
 public struct X86MMXType: IRType {
+
+  /// Returns the context associated with this module.
+  public let context: Context?
+  
   /// Creates an `X86MMXType`.
-  public init() {}
+  ///
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(in context: Context? = nil) {
+    self.context = context
+  }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
+    if let context = context {
+      return LLVMX86MMXTypeInContext(context.llvm)
+    }
     return LLVMX86MMXType()
   }
 }

--- a/Sources/LLVM/X86MMXType.swift
+++ b/Sources/LLVM/X86MMXType.swift
@@ -11,21 +11,18 @@ import cllvm
 public struct X86MMXType: IRType {
 
   /// Returns the context associated with this module.
-  public let context: Context?
-  
+  public let context: Context
+
   /// Creates an `X86MMXType`.
   ///
   /// - parameter context: The context to create this type in
   /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
-  public init(in context: Context? = nil) {
+  public init(in context: Context = Context.global) {
     self.context = context
   }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    if let context = context {
-      return LLVMX86MMXTypeInContext(context.llvm)
-    }
-    return LLVMX86MMXType()
+    return LLVMX86MMXTypeInContext(context.llvm)
   }
 }


### PR DESCRIPTION
Without the ability to emit types specific to a context modules with non global contexts are invalid if they contain any types.

Note this does change some public interfaces. Most notably `FloatType` is no longer just an `enum` of value as it must also store an associated `Context`