### PR TITLE
Switch to built-in SWIFT_PACKAGE flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,11 @@ compiler projects!
 
 We really recommend using SwiftPM with LLVMSwift, but if your project is
 structured in such a way that makes using SwiftPM impractical or impossible,
-you can still use LLVMSwift by passing the `-DNO_SWIFTPM` to swift when
-compiling.
+use the following instructions: 
 
 - Xcode:
   - Add this repository as a git submodule
   - Add the files in `Sources/` to your Xcode project.
-  - Under `Other Swift Flags`, add `-DNO_SWIFTPM`.
   - Under `Library Search Paths` add the output of `llvm-config --libdir`
   - Under `Header Search Paths` add the output of `llvm-config --includedir`
   - Under `Link Target with Libraries` drag in

--- a/Sources/LLVM/Alias.swift
+++ b/Sources/LLVM/Alias.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/ArrayType.swift
+++ b/Sources/LLVM/ArrayType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/BasicBlock.swift
+++ b/Sources/LLVM/BasicBlock.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Call.swift
+++ b/Sources/LLVM/Call.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Clause.swift
+++ b/Sources/LLVM/Clause.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Constant.swift
+++ b/Sources/LLVM/Constant.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/FloatType.swift
+++ b/Sources/LLVM/FloatType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Function.swift
+++ b/Sources/LLVM/Function.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/FunctionType.swift
+++ b/Sources/LLVM/FunctionType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Global.swift
+++ b/Sources/LLVM/Global.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/IRGlobal.swift
+++ b/Sources/LLVM/IRGlobal.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/IRType.swift
+++ b/Sources/LLVM/IRType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/IRValue+Kinds.swift
+++ b/Sources/LLVM/IRValue+Kinds.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/IRValue.swift
+++ b/Sources/LLVM/IRValue.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Initialization.swift
+++ b/Sources/LLVM/Initialization.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Instruction.swift
+++ b/Sources/LLVM/Instruction.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/IntType.swift
+++ b/Sources/LLVM/IntType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/JIT.swift
+++ b/Sources/LLVM/JIT.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/LabelType.swift
+++ b/Sources/LLVM/LabelType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Linkage.swift
+++ b/Sources/LLVM/Linkage.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/MemoryBuffer.swift
+++ b/Sources/LLVM/MemoryBuffer.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/MetadataType.swift
+++ b/Sources/LLVM/MetadataType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/ObjectFile.swift
+++ b/Sources/LLVM/ObjectFile.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/OpCode.swift
+++ b/Sources/LLVM/OpCode.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/PassManager.swift
+++ b/Sources/LLVM/PassManager.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/PhiNode.swift
+++ b/Sources/LLVM/PhiNode.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/PointerType.swift
+++ b/Sources/LLVM/PointerType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/StructType.swift
+++ b/Sources/LLVM/StructType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Switch.swift
+++ b/Sources/LLVM/Switch.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/TargetData.swift
+++ b/Sources/LLVM/TargetData.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/TargetMachine.swift
+++ b/Sources/LLVM/TargetMachine.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/TokenType.swift
+++ b/Sources/LLVM/TokenType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/Use.swift
+++ b/Sources/LLVM/Use.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/VectorType.swift
+++ b/Sources/LLVM/VectorType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/VoidType.swift
+++ b/Sources/LLVM/VoidType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 

--- a/Sources/LLVM/X86MMXType.swift
+++ b/Sources/LLVM/X86MMXType.swift
@@ -1,4 +1,4 @@
-#if !NO_SWIFTPM
+#if SWIFT_PACKAGE
 import cllvm
 #endif
 


### PR DESCRIPTION
Remove `NO_SWIFTPM` - SwiftPM already defines a flag for its builds, we don't need to make the user specify their own. 

Jazzy and its dependencies just... broke with the version of Ruby installed on my box.  Somebody else will need to re-run it to update the docs.