### PR TITLE
Disable and rewrite Metadata and Token type inits

### DIFF
--- a/Sources/LLVM/IRType.swift
+++ b/Sources/LLVM/IRType.swift
@@ -78,11 +78,11 @@ internal func convertType(_ type: LLVMTypeRef) -> IRType {
     let count = Int(LLVMGetVectorSize(type))
     return VectorType(elementType: elementType, count: count)
   case LLVMMetadataTypeKind:
-    return MetadataType(llvm: type)
+    return MetadataType(in: context)
   case LLVMX86_MMXTypeKind:
     return X86MMXType(in: context)
   case LLVMTokenTypeKind:
-    return TokenType(llvm: type)
+    return TokenType(in: context)
   default: fatalError("unknown type kind for type \(type)")
   }
 }

--- a/Sources/LLVM/MetadataType.swift
+++ b/Sources/LLVM/MetadataType.swift
@@ -5,15 +5,19 @@ import cllvm
 /// The `MetadataType` type represents embedded metadata. No derived types may
 /// be created from metadata except for function arguments.
 public struct MetadataType: IRType {
-  internal let llvm: LLVMTypeRef
+  /// Returns the context associated with this type.
+  public let context: Context
 
   /// Creates an embedded metadata type for the given LLVM type object.
-  public init(llvm: LLVMTypeRef) {
-    self.llvm = llvm
+  ///
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(in context: Context = Context.global) {
+    self.context = context
   }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    return llvm
+    fatalError("This version of LLVM does not support the creation of MetadataType objects")
   }
 }

--- a/Sources/LLVM/TokenType.swift
+++ b/Sources/LLVM/TokenType.swift
@@ -6,13 +6,19 @@ import cllvm
 /// uses of the value must not attempt to introspect or obscure it. As such, it
 /// is not appropriate to have a `PHI` or `select` of type `TokenType`.
 public struct TokenType: IRType {
-  internal let llvm: LLVMTypeRef
+  /// Returns the context associated with this type.
+  public let context: Context
 
   /// Initializes a token type from the given LLVM type object.
-  public init(llvm: LLVMTypeRef) { self.llvm = llvm }
+  ///
+  /// - parameter context: The context to create this type in
+  /// - SeeAlso: http://llvm.org/docs/ProgrammersManual.html#achieving-isolation-with-llvmcontext
+  public init(in context: Context = Context.global) {
+    self.context = context
+  }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    return llvm
+    fatalError("This version of LLVM does not support the creation of TokenType objects")
   }
 }


### PR DESCRIPTION
These initializers do not have corresponding create calls in LLVM yet and so cannot possibly be used from user code.  Disable them with a message and update the API to the modern "*InContext"-style.