### PR TITLE
Update (Linux) to LLVM 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,18 @@ env:
   - LC_CTYPE=en_US.UTF-8
 matrix:
   include:
-  - os: osx
-    language: objective-c
-    osx_image: xcode9
-    before_install:
-    - export PATH=/usr/local/opt/llvm/bin:"${PATH}"
-    - brew update
-    - brew install llvm
-    - sudo swift utils/make-pkgconfig.swift
-    script:
-    - swift test
   - os: linux
     language: generic
     sudo: required
     dist: trusty
+    addons:
+      apt:
+        sources: ['llvm-toolchain-trusty-6.0']
     env:
-    - LLVM_API_VERSION=5.0
+    - LLVM_API_VERSION=6.0
     before_install:
     - export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:"${PKG_CONFIG_PATH}"
-    - wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-${LLVM_API_VERSION}
-      main"
-    - sudo apt-get update
-    - sudo apt-get install llvm-${LLVM_API_VERSION} libc++1
+    - sudo apt-get install libc++1
     - sudo cp /usr/lib/x86_64-linux-gnu/libc++.so.1.0 /usr/lib/
     - sudo ln -sf /usr/lib/libc++.so.1.0 /usr/lib/libc++.so
     - sudo rm -rf /usr/local/clang-*/bin/llvm-config


### PR DESCRIPTION
For now, an experiment.  Once we start committing in earnest we will surely break the macOS build because I am far too lazy to make a custom formula that installs LLVM 6.0.