### PR TITLE
Enable Inert References

### DIFF
--- a/Sources/LLVM/Constant.swift
+++ b/Sources/LLVM/Constant.swift
@@ -165,7 +165,43 @@ extension Constant where Repr == Struct {
   }
 }
 
+// MARK: Truncation
 
+extension Constant where Repr == Signed {
+  /// Creates a constant truncated to a given integral type.
+  ///
+  /// - parameter type: The type to truncate towards.
+  ///
+  /// - returns: A const value representing this value truncated to the given
+  ///   integral type's bitwidth.
+  public func truncate(to type: IntType) -> Constant<Signed> {
+    return Constant<Signed>(llvm: LLVMConstTrunc(llvm, type.asLLVM()))
+  }
+}
+
+extension Constant where Repr == Unsigned {
+  /// Creates a constant truncated to a given integral type.
+  ///
+  /// - parameter type: The type to truncate towards.
+  ///
+  /// - returns: A const value representing this value truncated to the given
+  ///   integral type's bitwidth.
+  public func truncate(to type: IntType) -> Constant<Unsigned> {
+    return Constant<Unsigned>(llvm: LLVMConstTrunc(llvm, type.asLLVM()))
+  }
+}
+
+extension Constant where Repr == Floating {
+  /// Creates a constant truncated to a given floating type.
+  ///
+  /// - parameter type: The type to truncate towards.
+  ///
+  /// - returns: A const value representing this value truncated to the given
+  ///   floating type's bitwidth.
+  public func truncate(to type: FloatType) -> Constant<Floating> {
+    return Constant<Floating>(llvm: LLVMConstFPTrunc(llvm, type.asLLVM()))
+  }
+}
 
 // MARK: Arithmetic Operations
 
@@ -933,6 +969,23 @@ extension Constant {
   public static func select<T: IntegralConstantRepresentation, U>(_ cond: Constant<T>, then: Constant<U>, else: Constant<U>) -> Constant<U> {
     assert((cond.type as! IntType).width == 1)
     return Constant<U>(llvm: LLVMConstSelect(cond.llvm, then.llvm, `else`.llvm))
+  }
+}
+
+// MARK: Constant Pointer To Integer
+
+extension Constant where Repr: IntegralConstantRepresentation {
+  /// Creates a constant pointer-to-integer operation to convert the given constant
+  /// global pointer value to the given integer type.
+  ///
+  /// - parameter val: The pointer value.
+  /// - parameter intType: The destination integer type.
+  ///
+  /// - returns: An constant value representing the constant value of the given
+  ///   pointer converted to the given integer type.
+  public static func pointerToInt(_ val: IRGlobal, _ intType: IntType) -> Constant {
+    precondition(val.isConstant, "May only convert global constant pointers to integers")
+    return Constant<Repr>(llvm: LLVMConstPtrToInt(val.asLLVM(), intType.asLLVM()))
   }
 }
 

--- a/Sources/LLVM/IRGlobal.swift
+++ b/Sources/LLVM/IRGlobal.swift
@@ -32,6 +32,12 @@ extension IRGlobal {
     set { LLVMSetDLLStorageClass(asLLVM(), newValue.llvm) }
   }
 
+  /// Retrieves an indicator for the significance of a global value's address.
+  public var unnamedAddressKind: UnnamedAddressKind {
+    get { return UnnamedAddressKind(llvm: LLVMHasUnnamedAddr(asLLVM()))  }
+    set { LLVMSetUnnamedAddr(asLLVM(), newValue.llvm) }
+  }
+
   /// Retrieves the section associated with the symbol that will eventually be
   /// emitted for this global value.
   ///

--- a/Sources/LLVM/Linkage.swift
+++ b/Sources/LLVM/Linkage.swift
@@ -216,3 +216,49 @@ public enum StorageClass {
     return StorageClass.storageMapping[self]!
   }
 }
+
+/// Enumerates values representing whether or not this global value's address
+/// is significant in this module or the program at large.  A global value's
+/// address is considered significant if it is referenced by any module in the
+/// final program.
+///
+/// This attribute is intended to be used only by the code generator and LTO to
+/// allow the linker to decide whether the global needs to be in the symbol
+/// table.  Constant global values with unnamed addresses and identical
+/// initializers may be merged by LLVM.  Note that a global value with an
+/// unnamed address may be merged with a global value with a significant address
+/// resulting in a global value with a significant address.
+public enum UnnamedAddressKind {
+  /// Indicates that the address of this global value is significant
+  /// in this module.
+  case none
+
+  /// Indicates that the address of this global value is not significant to the
+  /// current module but it may or may not be significant to another module;
+  /// only the content of the value is known to be significant within the
+  /// current module.
+//  case local
+
+  /// Indicates that the address of this global value is not significant to the
+  /// current module or any other module; only the content of the value
+  /// is significant globally.
+  case global
+
+  private static let unnamedAddressMapping: [UnnamedAddressKind: LLVMBool] = [
+    .none: LLVMBool(0),
+//    .local: LLVMBool(1),
+    .global: LLVMBool(1),
+    ]
+
+  internal init(llvm: LLVMBool) {
+    switch llvm {
+    case 0: self = .none
+    case 1: self = .global
+    default: fatalError("unknown unnamed address kind \(llvm)")
+    }
+  }
+
+  internal var llvm: LLVMBool {
+    return UnnamedAddressKind.unnamedAddressMapping[self]!
+  }
+}

--- a/Tests/LLVMTests/IRGlobalSpec.swift
+++ b/Tests/LLVMTests/IRGlobalSpec.swift
@@ -20,11 +20,10 @@ class IRGlobalSpec : XCTestCase {
       gotGlobal.unnamedAddressKind = .global
       gotGlobal.isGlobalConstant = true
 
-      // IRINERTGLOBAL: @external_relative_reference = global i32 sub (i64 ptrtoint (i32** @got.external_global to i64), i64 ptrtoint (i32* @external_relative_reference to i64))
+      // IRINERTGLOBAL: @external_relative_reference = global i32 trunc (i64 sub (i64 ptrtoint (i32** @got.external_global to i64), i64 ptrtoint (i32* @external_relative_reference to i64)) to i32)
       var ext_relative_reference = builder.addGlobal("external_relative_reference", type: IntType.int32)
-      ext_relative_reference.initializer =  Constant<Unsigned>.pointerToInt(gotGlobal, .int64)
-        .subtracting(Constant<Unsigned>.pointerToInt(ext_relative_reference, .int64))
-
+      ext_relative_reference.initializer = Constant<Unsigned>.pointerToInt(gotGlobal, .int64)
+        .subtracting(Constant<Unsigned>.pointerToInt(ext_relative_reference, .int64)).truncate(to: .int32)
       module.dump()
     })
   }

--- a/Tests/LLVMTests/IRGlobalSpec.swift
+++ b/Tests/LLVMTests/IRGlobalSpec.swift
@@ -1,0 +1,38 @@
+import LLVM
+import XCTest
+import FileCheck
+import Foundation
+
+class IRGlobalSpec : XCTestCase {
+  func testIRInertGlobal() {
+    XCTAssert(fileCheckOutput(of: .stderr, withPrefixes: ["IRINERTGLOBAL"]) {
+      // IRINERTGLOBAL: ; ModuleID = '[[ModuleName:IRInertGlobalTest]]'
+      // IRINERTGLOBAL-NEXT: source_filename = "[[ModuleName]]"
+      let module = Module(name: "IRInertGlobalTest")
+      let builder = IRBuilder(module: module)
+      // IRINERTGLOBAL: @external_global = external constant i32
+      var extGlobal = builder.addGlobal("external_global", type: IntType.int32)
+      extGlobal.isGlobalConstant = true
+      // IRINERTGLOBAL: @got.external_global = private unnamed_addr constant i32* @external_global
+      var gotGlobal = builder.addGlobal("got.external_global",
+                                        initializer: extGlobal)
+      gotGlobal.linkage = .`private`
+      gotGlobal.unnamedAddressKind = .global
+      gotGlobal.isGlobalConstant = true
+
+      // IRINERTGLOBAL: @external_relative_reference = global i32 sub (i64 ptrtoint (i32** @got.external_global to i64), i64 ptrtoint (i32* @external_relative_reference to i64))
+      var ext_relative_reference = builder.addGlobal("external_relative_reference", type: IntType.int32)
+      ext_relative_reference.initializer =  Constant<Unsigned>.pointerToInt(gotGlobal, .int64)
+        .subtracting(Constant<Unsigned>.pointerToInt(ext_relative_reference, .int64))
+
+      module.dump()
+    })
+  }
+
+  #if !os(macOS)
+  static var allTests = testCase([
+    ("testIRInertGlobal", testIRInertGlobal),
+  ])
+  #endif
+}
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,11 +4,12 @@ import XCTest
 
 #if !os(macOS)
 XCTMain([
-  IRBuilderSpec.allTests,
   ConstantSpec.allTests,
-  IRExceptionSpec.allTests,
-  IROperationSpec.allTests,
   FileCheckSpec.allTests,
+  IRBuilderSpec.allTests,
+  IRExceptionSpec.allTests,
+  IRGlobalSpec.allTests,
+  IROperationSpec.allTests,
   JITSpec.allTests,
   ModuleLinkSpec.allTests,
 ])


### PR DESCRIPTION
Adds the constant operations necessary to build [load-time inert references](http://duriansoftware.com/joe/Optimizing-global-constant-data-structures-using-relative-references.html).