### PR TITLE
Update to Swift 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
   - os: osx
     language: objective-c
-    osx_image: xcode9.3
+    osx_image: xcode10
     before_install:
     - export PATH=/usr/local/opt/llvm/bin:"${PATH}"
     - brew update
@@ -33,10 +33,10 @@ matrix:
     - sudo rm -f /usr/bin/llvm-config
     - sudo ln -s /usr/bin/llvm-config-${LLVM_API_VERSION} /usr/bin/llvm-config
     - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-    - wget https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz
-    - tar xzf swift-4.1-RELEASE-ubuntu14.04.tar.gz
-    - export PATH=${PWD}/swift-4.1-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
-    - sudo ./swift-4.1-RELEASE-ubuntu14.04/usr/bin/swift utils/make-pkgconfig.swift
+    - wget https://swift.org/builds/swift-4.2-release/ubuntu1404/swift-4.2-RELEASE/swift-4.2-RELEASE-ubuntu14.04.tar.gz
+    - tar xzf swift-4.2-RELEASE-ubuntu14.04.tar.gz
+    - export PATH=${PWD}/swift-4.2-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
+    - sudo ./swift-4.2-RELEASE-ubuntu14.04/usr/bin/swift utils/make-pkgconfig.swift
     script:
     - swift test
 notifications:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 
 import PackageDescription
 
@@ -10,12 +10,18 @@ let package = Package(
       targets: ["LLVM"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/llvm-swift/cllvm.git", from: "0.0.3"),
     .package(url: "https://github.com/llvm-swift/FileCheck.git", from: "0.0.3"),
   ],
   targets: [
+    .systemLibrary(
+      name: "cllvm",
+      pkgConfig: "cllvm",
+      providers: [
+          .brew(["llvm"]),
+      ]),
     .target(
-      name: "LLVM"),
+      name: "LLVM",
+      dependencies: ["cllvm"]),
     .testTarget(
       name: "LLVMTests",
       dependencies: ["LLVM", "FileCheck"]),

--- a/Sources/LLVM/MemoryBuffer.swift
+++ b/Sources/LLVM/MemoryBuffer.swift
@@ -110,7 +110,7 @@ public class MemoryBuffer: Sequence {
   }
 
   /// Makes an iterator so this buffer can be traversed in a `for` loop.
-  public func makeIterator() -> UnsafeBufferPointerIterator<Int8> {
+  public func makeIterator() -> UnsafeBufferPointer<Int8>.Iterator {
     return UnsafeBufferPointer(start: start, count: size).makeIterator()
   }
 

--- a/Sources/cllvm/module.modulemap
+++ b/Sources/cllvm/module.modulemap
@@ -1,0 +1,4 @@
+module cllvm [system] {
+  header "shim.h"
+  export *
+}

--- a/Sources/cllvm/shim.h
+++ b/Sources/cllvm/shim.h
@@ -1,0 +1,30 @@
+#define _DEBUG
+#define _GNU_SOURCE
+#define __STDC_CONSTANT_MACROS
+#define __STDC_FORMAT_MACROS
+#define __STDC_LIMIT_MACROS
+
+#include <llvm-c/Analysis.h>
+#include <llvm-c/BitReader.h>
+#include <llvm-c/BitWriter.h>
+#include <llvm-c/Core.h>
+#include <llvm-c/DebugInfo.h>
+#include <llvm-c/Disassembler.h>
+#include <llvm-c/ErrorHandling.h>
+#include <llvm-c/ExecutionEngine.h>
+#include <llvm-c/Initialization.h>
+#include <llvm-c/IRReader.h>
+#include <llvm-c/Linker.h>
+#include <llvm-c/LinkTimeOptimizer.h>
+#include <llvm-c/lto.h>
+#include <llvm-c/Object.h>
+#include <llvm-c/OrcBindings.h>
+#include <llvm-c/Support.h>
+#include <llvm-c/Target.h>
+#include <llvm-c/TargetMachine.h>
+#include <llvm-c/Transforms/IPO.h>
+#include <llvm-c/Transforms/PassManagerBuilder.h>
+#include <llvm-c/Transforms/Scalar.h>
+#include <llvm-c/Transforms/Vectorize.h>
+#include <llvm-c/Types.h>
+

--- a/Tests/LLVMTests/JITSpec.swift
+++ b/Tests/LLVMTests/JITSpec.swift
@@ -63,9 +63,9 @@ class JITSpec : XCTestCase {
       // Retrieve a handle to the function we're going to invoke
       let fnAddr = jit.addressOfFunction(name: "calculateFibs")
       let fn = unsafeBitCast(fnAddr, to: FnPtr.self)
-      // JIT: 0.00917431192660551
+      // JIT: 0.009174311926605505
       print(fn(true))
-      // JIT-NEXT: 0.0112359550561798
+      // JIT-NEXT: 0.011235955056179775
       print(fn(false))
     })
   }


### PR DESCRIPTION
- Bump the CI scripts to build with Xcode 10 and Swift 4.2
- Internalize the cllvm package as a system library
- Fix a JIT test that is now failing because of the new floating point printer in Swift 4.2