### PR TITLE
Remove define of _DEBUG

### DIFF
--- a/Sources/cllvm/shim.h
+++ b/Sources/cllvm/shim.h
@@ -1,4 +1,3 @@
-#define _DEBUG
 #define _GNU_SOURCE
 #define __STDC_CONSTANT_MACROS
 #define __STDC_FORMAT_MACROS


### PR DESCRIPTION
This shouldn't be necessary and actually breaks local package builds against the 10.14 SDK sometimes for reasons I have yet to figure out.