### PR TITLE
Introduce the Size and Alignment Types

### DIFF
--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -77,15 +77,14 @@ public final class Module: CustomStringConvertible {
       llvm = LLVMModuleCreateWithName(name)
       self.context = Context(llvm: LLVMGetModuleContext(llvm)!)
     }
+    self.dataLayout = TargetData(llvm: LLVMGetModuleDataLayout(llvm))
   }
 
   /// Returns the context associated with this module.
   public let context: Context
 
   /// Obtain the data layout for this module.
-  public var dataLayout: TargetData {
-    return TargetData(llvm: LLVMGetModuleDataLayout(llvm))
-  }
+  public var dataLayout: TargetData
 
   /// The identifier of this module.
   public var name: String {

--- a/Sources/LLVM/StructType.swift
+++ b/Sources/LLVM/StructType.swift
@@ -115,4 +115,22 @@ public struct StructType: IRType {
   public func asLLVM() -> LLVMTypeRef {
     return llvm
   }
+
+  /// Return true if this is a struct type with an identity that has an
+  /// unspecified body.
+  ///
+  /// Opaque struct types print as `opaque` in serialized .ll files.
+  public var isOpaque: Bool {
+    return LLVMIsOpaqueStruct(self.llvm) != 0
+  }
+
+  /// Returns true if this is a packed struct type.
+  ///
+  /// A packed struct type includes no padding between fields and is thus
+  /// laid out in one contiguous region of memory with its elements laid out
+  /// one after the other.  A non-packed struct type includes padding according
+  /// to the data layout of the target.
+  public var isPacked: Bool {
+    return LLVMIsPackedStruct(self.llvm) != 0
+  }
 }

--- a/Sources/LLVM/TargetData.swift
+++ b/Sources/LLVM/TargetData.swift
@@ -173,8 +173,22 @@ public class TargetData {
     return cachedLayout
   }
 
+  /// Returns the next integer (mod 2**64) that is greater than or equal to
+  /// \p Value and is a multiple of \p Align. \p Align must be non-zero.
+  ///
+  /// If non-zero \p Skew is specified, the return value will be a minimal
+  /// integer that is greater than or equal to \p Value and equal to
+  /// \p Align * N + \p Skew for some integer N. If \p Skew is larger than
+  /// \p Align, its value is adjusted to '\p Skew mod \p Align'.
+  ///
+  /// Computes the next size value that is greater than or equal to the given
+  /// value and is a multiple of the given alignment.
+  ///
+  /// If the skew value is non-zero, the return value will be the next size
+  /// value that is greater than or equal to the given value multipled by the
+  /// provided alignment with a skew value added
   public static func align(_ value: Size, to align: Alignment, skew: Size = Size.zero) -> Size {
-    precondition(align != Alignment.zero, "Align can't be 0.")
+    precondition(!align.isZero, "Align can't be 0.")
 
     let skewValue = skew.rawValue % UInt64(align.rawValue)
     let alignValue = UInt64(align.rawValue)

--- a/Sources/LLVM/Units.swift
+++ b/Sources/LLVM/Units.swift
@@ -1,0 +1,294 @@
+/// An alignment value, expressed in bytes.
+public struct Alignment: Comparable, Hashable {
+  /// Accesses the raw alignment value in bytes.
+  ///
+  /// - warning: This accessor allows breaking out of the Alignment abstraction
+  ///   for raw alignment calculations.  It is therefore not recommended that
+  ///   this accessor be used in user code.
+  public let rawValue: UInt32
+
+  /// A zero-byte alignment value.
+  public static let zero = Alignment(0)
+  /// An one-byte alignment value.
+  public static let one = Alignment(1)
+
+  /// Initializes and returns an alignment with the given value interpreted as
+  /// a quantity of bytes.
+  public init(_ value: UInt32) {
+    self.rawValue = value
+  }
+
+  /// Returns true if this alignment value is zero bytes, else return false.
+  public var isZero: Bool {
+    return self.rawValue == 0
+  }
+
+  /// Returns the log-base-two value of this alignment as a 32-bit integer.
+  ///
+  /// An n-byte alignment contains log-base-two-many least-significant zeros.
+  public func log2() -> UInt32 {
+    return 31 - UInt32(self.rawValue.leadingZeroBitCount)
+  }
+
+  /// Returns the log-base-two value of this alignment as a 64-bit integer.
+  ///
+  /// An n-byte alignment contains log-base-two-many least-significant zeros.
+  public func log2() -> UInt64 {
+    return 63 - UInt64(self.rawValue.leadingZeroBitCount)
+  }
+  
+  /// Returns the alignment of a pointer which points to the given number of
+  /// bytes after a pointer with this alignment.
+  public func alignment(at offset: Size) -> Alignment {
+    assert(self.rawValue != 0, "called on object with zero alignment")
+
+    // If the offset is zero, use the original alignment.
+    var V = Int32(offset.rawValue)
+    guard V != 0 else {
+      return self
+    }
+
+    // Find the offset's largest power-of-two factor.
+    V = V & -V
+
+    // The alignment at the offset is then the min of the two values.
+    guard V < self.rawValue else {
+      return self
+    }
+
+    return Alignment(UInt32(V))
+  }
+
+  public static func == (lhs: Alignment, rhs: Alignment) -> Bool {
+    return lhs.rawValue == rhs.rawValue
+  }
+
+  public static func < (lhs: Alignment, rhs: Alignment) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    self.rawValue.hash(into: &hasher)
+  }
+}
+
+/// This is an opaque type for sizes expressed in aggregate bit units, usually 8
+/// bits per unit.
+///
+/// Instances of this type represent a quantity as a multiple of a radix size
+/// - e.g. the size of a `char` in bits on the target architecture. As an opaque
+/// type, `Size` protects you from accidentally combining operations on
+/// quantities in bit units and size units.
+///
+/// For portability, never assume that a target radix is 8 bits wide. Use
+/// Size values wherever you calculate sizes and offsets.
+public struct Size {
+  /// Accesses the raw value unitless value of this size.
+  ///
+  /// - warning: This accessor breaks the `Size` abstraction by allowing access
+  ///   to the raw value. The underlying value is unitless and hence any
+  ///   reinterpretation may lead to incorrect results in calculations that
+  ///   depend on precise bit and byte-level arithmetic.  This accessor should
+  ///   not be used by user code in general.
+  public let rawValue: UInt64
+
+  /// A size carrying a value of zero.
+  public static let zero = Size(0)
+  /// A size carrying a value of one.
+  public static let one = Size(1)
+
+  /// Initializes and returns a size carrying the given value.
+  public init(_ value: UInt64) {
+    self.rawValue = value
+  }
+
+  /// Initializes and returns a size carrying the given value which represents
+  /// a value in bits with a given radix.
+  ///
+  /// - parameter bitSize: A given number of bits.
+  /// - parameter radix: The radix value. Defaults to 8 bits per size unit.
+  public init(bits bitSize: UInt64, radix: UInt64 = 8) {
+    precondition(radix > 0, "radix cannot be 0")
+    self.rawValue = (bitSize + (radix - 1)) / radix
+  }
+
+  /// Returns the value of this size in bits according to a given radix.
+  ///
+  /// - parameter radix: The radix value. Defaults to 8 bits per size unit.
+  /// - returns: A value in bits.
+  public func valueInBits(radix: UInt64 = 8) -> UInt64 {
+    return self.rawValue * radix
+  }
+
+  /// Returns true if this size value is a power of two, including if it is
+  /// zero.  Returns false otherwise.
+  public var isPowerOfTwo: Bool {
+    return (self.rawValue != 0)
+        && ((self.rawValue & (self.rawValue - 1)) == 0)
+  }
+
+  /// Computes a size with value rounded up to the next highest value that is
+  /// a multiple of the given alignment value.
+  ///
+  /// - parameter alignment: The alignment value.  Must not be zero.
+  /// - returns: A size representing the given value rounded up to the given
+  ///   alignment value.
+  public func roundUp(to alignment: Alignment) -> Size {
+    precondition(!alignment.isZero, "Cannot round up with zero alignment!")
+    let mask = UInt64(alignment.rawValue - 1)
+    let value = self.rawValue + mask
+    return Size(value & ~mask)
+  }
+}
+
+extension Size: UnsignedInteger {
+  public init<T>(clamping source: T) where T : BinaryInteger {
+    self.init(UInt64(clamping: source))
+  }
+
+  public init<T>(truncatingIfNeeded source: T) where T : BinaryInteger {
+    self.init(UInt64(clamping: source))
+  }
+
+  public init?<T>(exactly source: T) where T : BinaryInteger {
+    guard let val = UInt64(exactly: source) else {
+      return nil
+    }
+    self.init(val)
+  }
+
+  public init(integerLiteral value: UInt64) {
+    self.init(value)
+  }
+
+  public init?<T>(exactly source: T) where T : BinaryFloatingPoint {
+    guard let val = UInt64(exactly: source) else {
+      return nil
+    }
+    self.init(val)
+  }
+
+  public init<T>(_ source: T) where T : BinaryFloatingPoint {
+    self.init(UInt64(source))
+  }
+
+  public init<T>(_ source: T) where T : BinaryInteger {
+    self.init(UInt64(source))
+  }
+
+  public var words: UInt64.Words {
+    return self.rawValue.words
+  }
+
+  public var bitWidth: Int {
+    return self.rawValue.bitWidth
+  }
+
+  public var trailingZeroBitCount: Int {
+    return self.rawValue.trailingZeroBitCount
+  }
+
+  public static func == (lhs: Size, rhs: Size) -> Bool {
+    return lhs.rawValue == rhs.rawValue
+  }
+
+  public static func < (lhs: Size, rhs: Size) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+
+
+  public func hash(into hasher: inout Hasher) {
+    self.rawValue.hash(into: &hasher)
+  }
+
+  public static func + (lhs: Size, rhs: Size) -> Size {
+    var lhs = lhs
+    lhs += rhs
+    return lhs
+  }
+  public static func += (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue + rhs.rawValue)
+  }
+
+  public static func - (lhs: Size, rhs: Size) -> Size {
+    var lhs = lhs
+    lhs -= rhs
+    return lhs
+  }
+  public static func -= (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue - rhs.rawValue)
+  }
+
+  public static func * (lhs: Size, rhs: Size) -> Size {
+    var lhs = lhs
+    lhs *= rhs
+    return lhs
+  }
+  public static func *= (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue * rhs.rawValue)
+  }
+
+  public static func * (lhs: Size, rhs: UInt64) -> Size {
+    var lhs = lhs
+    lhs *= Size(rhs)
+    return lhs
+  }
+  public static func * (lhs: UInt64, rhs: Size) -> Size {
+    var lhs = Size(lhs)
+    lhs *= rhs
+    return lhs
+  }
+  public static func *= (lhs: inout Size, rhs: UInt64) {
+    lhs = Size(lhs.rawValue * rhs)
+  }
+
+  public static func / (lhs: Size, rhs: Size) -> Size {
+    var lhs = lhs
+    lhs /= rhs
+    return lhs
+  }
+  public static func /= (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue / rhs.rawValue)
+  }
+
+  public static func % (lhs: Size, rhs: Size) -> Size {
+    var lhs = lhs
+    lhs %= rhs
+    return lhs
+  }
+  public static func %= (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue % rhs.rawValue)
+  }
+
+  public static func &= (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue & rhs.rawValue)
+  }
+
+  public static func |= (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue & rhs.rawValue)
+  }
+
+  public static func ^= (lhs: inout Size, rhs: Size) {
+    lhs = Size(lhs.rawValue ^ rhs.rawValue)
+  }
+
+  public static func >>= <RHS: BinaryInteger>(lhs: inout Size, rhs: RHS) {
+    lhs = Size(lhs.rawValue >> rhs)
+  }
+
+  public static func <<= <RHS: BinaryInteger>(lhs: inout Size, rhs: RHS) {
+    lhs = Size(lhs.rawValue >> rhs)
+  }
+
+  public static prefix func ~ (x: Size) -> Size {
+    return Size(~x.rawValue)
+  }
+
+  /// Returns true if the given size is a multiple of this size.
+  public func isMultiple(of other: Size) -> Bool {
+    return (self.rawValue % other.rawValue) == 0
+  }
+
+  public typealias IntegerLiteralType = UInt64
+  public typealias Words = UInt64.Words
+}

--- a/Tests/LLVMTests/UnitSpec.swift
+++ b/Tests/LLVMTests/UnitSpec.swift
@@ -1,0 +1,89 @@
+import LLVM
+import XCTest
+import Foundation
+
+class UnitSpec : XCTestCase {
+  func testAlign() {
+    let expectations: [(Size, Alignment, Size)] = [
+      (Size(5), Alignment(8), Size(8)),
+      (Size(17), Alignment(8), Size(24)),
+      (Size(321), Alignment(255), Size(510)),
+    ]
+
+    for (argSize, argAlign, expect) in expectations {
+      XCTAssertEqual(TargetData.align(argSize, to: argAlign), expect)
+    }
+
+    let expectationsWithSkew: [(Size, Alignment, Size, Size)] = [
+      (Size(5), Alignment(8), Size(7), Size(7)),
+      (Size(17), Alignment(8), Size(1), Size(17)),
+      (Size(321), Alignment(255), Size(42), Size(552)),
+    ]
+
+    for (argSize, argAlign, argSkew, expect) in expectationsWithSkew {
+      XCTAssertEqual(TargetData.align(argSize, to: argAlign, skew: argSkew), expect)
+    }
+  }
+
+  func testEmptyStructLayout() {
+    let mod = Module(name: "StructLayout")
+
+    let emptyPackedStruct = StructType(elementTypes: [], isPacked: true, in: Context.global)
+    let emptyUnpackedStruct = StructType(elementTypes: [], isPacked: false, in: Context.global)
+
+    let emptyPackedLayout = mod.dataLayout.layout(of: emptyPackedStruct)
+    XCTAssertEqual(emptyPackedLayout.alignment, Alignment.one)
+    XCTAssertEqual(emptyPackedLayout.size, Size.zero)
+    XCTAssertEqual(emptyPackedLayout.elementCount, 0)
+    XCTAssertFalse(emptyPackedLayout.isPadded)
+    let emptyUnpackedLayout = mod.dataLayout.layout(of: emptyUnpackedStruct)
+    XCTAssertEqual(emptyUnpackedLayout.alignment, Alignment.one)
+    XCTAssertEqual(emptyUnpackedLayout.size, Size.zero)
+    XCTAssertEqual(emptyUnpackedLayout.elementCount, 0)
+    XCTAssertFalse(emptyUnpackedLayout.isPadded)
+  }
+
+  func testStructLayout() {
+    let mod = Module(name: "StructLayout")
+
+    let packedStruct = StructType(elementTypes: [
+      IntType.int1,
+      IntType.int8,
+      IntType.int1,
+      PointerType(pointee: IntType.int8),
+    ], isPacked: true, in: Context.global)
+    let unpackedStruct = StructType(elementTypes: [
+      IntType.int1,
+      IntType.int8,
+      IntType.int1,
+      PointerType(pointee: IntType.int8),
+    ], isPacked: false, in: Context.global)
+
+    let packedLayout = mod.dataLayout.layout(of: packedStruct)
+    XCTAssertEqual(packedLayout.alignment, Alignment.one)
+    XCTAssertEqual(packedLayout.size, Size(11))
+    XCTAssertEqual(packedLayout.elementCount, 4)
+    XCTAssertFalse(packedLayout.isPadded)
+    XCTAssertEqual(packedLayout.memberOffsets, [
+      Size(0), Size(1), Size(2), Size(3),
+    ])
+    let unpackedLayout = mod.dataLayout.layout(of: unpackedStruct)
+    XCTAssertEqual(unpackedLayout.alignment, Alignment(8))
+    XCTAssertEqual(unpackedLayout.size, Size(16))
+    XCTAssertEqual(unpackedLayout.elementCount, 4)
+    XCTAssertTrue(unpackedLayout.isPadded)
+    XCTAssertEqual(unpackedLayout.memberOffsets, [
+      Size(0), Size(1), Size(2), Size(8),
+    ])
+  }
+
+
+  #if !os(macOS)
+  static var allTests = testCase([
+    ("testAlign", testAlign),
+    ("testEmptyStructLayout", testEmptyStructLayout),
+    ("testStructLayout", testStructLayout),
+  ])
+  #endif
+}
+


### PR DESCRIPTION
Add an equivalent to [clang::CharUnits](https://clang.llvm.org/doxygen/classclang_1_1CharUnits.html) in the form of the `Size` type.  Like `CharUnits`, `Size` is an opaque numeric type.  Unlike `CharUnits`, size is language-agnostic and is hence unitless.  The default mode of use for `Size` is to represent a byte.  In particular, an 8-bit byte.

`Alignment` is an equivalent to `swift::Alignment`, a type that expresses an alignment in a given number of bytes. 

Conveniences are provided to perform common operations on sizes like rounding them up to a given alignment and taking the log of an alignment value to compute padding values.