### PR TITLE
Pass valid count pointer to `LLVMGetModuleIdentifier`

### DIFF
--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -110,7 +110,8 @@ public final class Module: CustomStringConvertible {
   /// The identifier of this module.
   public var name: String {
     get {
-      guard let id = LLVMGetModuleIdentifier(llvm, nil) else { return "" }
+      var count = 0
+      guard let id = LLVMGetModuleIdentifier(llvm, &count) else { return "" }
       return String(cString: id)
     }
     set {

--- a/Tests/LLVMTests/ModuleLinkSpec.swift
+++ b/Tests/LLVMTests/ModuleLinkSpec.swift
@@ -9,6 +9,7 @@ class ModuleLinkSpec : XCTestCase {
       // MODULE-LINK: ; ModuleID = '[[ModuleName1:ModuleLinkModuleOne]]'
       // MODULE-LINK-NEXT: source_filename = "[[ModuleName1]]"
       let module1 = Module(name: "ModuleLinkModuleOne")
+      XCTAssertEqual(module1.name, "ModuleLinkModuleOne")
       let builder1 = IRBuilder(module: module1)
       // MODULE-LINK: define void @moduleOne() {
       let mod1f = builder1.addFunction("moduleOne",
@@ -25,6 +26,7 @@ class ModuleLinkSpec : XCTestCase {
       // MODULE-LINK: ; ModuleID = '[[ModuleName2:ModuleLinkModuleTwo]]'
       // MODULE-LINK-NEXT: source_filename = "[[ModuleName2]]"
       let module2 = Module(name: "ModuleLinkModuleTwo")
+      XCTAssertEqual(module2.name, "ModuleLinkModuleTwo")
       let builder2 = IRBuilder(module: module2)
       // MODULE-LINK: define void @moduleTwo() {
       let mod2f = builder2.addFunction("moduleTwo",


### PR DESCRIPTION
`Module.name` was passing `nil` to arg 2 of `LLVMGetModuleIdentifier`, which appears to cause a seg fault every time it is called because it always tries to write the count to the pointer.

Fixed by using dummy `count` variable and passing it `inout`.
Added test assertions to Module link test.