### PR TITLE
Miscellaneous missing bindings from LLVM 7.0

### DIFF
--- a/Sources/LLVM/Alias.swift
+++ b/Sources/LLVM/Alias.swift
@@ -11,4 +11,22 @@ public struct Alias: IRGlobal {
   public func asLLVM() -> LLVMValueRef {
     return llvm
   }
+
+  /// Access the target value of this alias.
+  public var aliasee: IRValue {
+    get { return LLVMAliasGetAliasee(llvm) }
+    set { LLVMAliasSetAliasee(llvm, newValue.asLLVM()) }
+  }
+
+  /// Retrieves the previous alias in the module, if there is one.
+  public func previous() -> Alias? {
+    guard let previous = LLVMGetPreviousGlobalAlias(llvm) else { return nil }
+    return Alias(llvm: previous)
+  }
+
+  /// Retrieves the next alias in the module, if there is one.
+  public func next() -> Alias? {
+    guard let next = LLVMGetNextGlobalAlias(llvm) else { return nil }
+    return Alias(llvm: next)
+  }
 }

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -230,6 +230,29 @@ public final class Module: CustomStringConvertible {
     }
   }
 
+  /// Retrieves the sequence of aliases that make up this module.
+  public var aliases: AnySequence<Alias> {
+    var current = firstAlias
+    return AnySequence<Alias> {
+      return AnyIterator<Alias> {
+        defer { current = current?.next() }
+        return current
+      }
+    }
+  }
+
+  /// Retrieves the first alias in this module, if there are any aliases.
+  public var firstAlias: Alias? {
+    guard let fn = LLVMGetFirstGlobalAlias(llvm) else { return nil }
+    return Alias(llvm: fn)
+  }
+
+  /// Retrieves the last alias in this module, if there are any aliases.
+  public var lastAlias: Alias? {
+    guard let fn = LLVMGetLastGlobalAlias(llvm) else { return nil }
+    return Alias(llvm: fn)
+  }
+
   /// The current debug metadata version number.
   public static var debugMetadataVersion: UInt32 {
     return LLVMDebugMetadataVersion();
@@ -305,6 +328,18 @@ extension Module {
   public func function(named name: String) -> Function? {
     guard let fn = LLVMGetNamedFunction(llvm, name) else { return nil }
     return Function(llvm: fn)
+  }
+
+  /// Searches for and retrieves an alias with the given name in this module
+  /// if that name references an existing alias.
+  ///
+  /// - parameter name: The name of the alias to search for.
+  ///
+  /// - returns: A representation of an alias with the given
+  ///   name or nil if no such named alias exists.
+  public func alias(named name: String) -> Alias? {
+    guard let alias = LLVMGetNamedGlobalAlias(llvm, name, name.count) else { return nil }
+    return Alias(llvm: alias)
   }
 
   /// Searches for and retrieves a comdat section with the given name in this

--- a/Sources/LLVM/PassManager.swift
+++ b/Sources/LLVM/PassManager.swift
@@ -60,6 +60,8 @@ public enum FunctionPass {
   case loopReroll
   /// This pass is a simple loop unrolling pass.
   case loopUnroll
+  /// This pass is a simple loop unroll-and-jam pass.
+  case loopUnrollAndJam
   /// This pass is a simple loop unswitching pass.
   case loopUnswitch
   /// This pass performs optimizations related to eliminating `memcpy` calls
@@ -198,6 +200,7 @@ public class FunctionPassManager {
     .loopRotate: LLVMAddLoopRotatePass,
     .loopReroll: LLVMAddLoopRerollPass,
     .loopUnroll: LLVMAddLoopUnrollPass,
+    .loopUnrollAndJam: LLVMAddLoopUnrollAndJamPass,
     .loopUnswitch: LLVMAddLoopUnswitchPass,
     .memCpyOpt: LLVMAddMemCpyOptPass,
     .partiallyInlineLibCalls: LLVMAddPartiallyInlineLibCallsPass,

--- a/Tests/LLVMTests/ModuleMetadataSpec.swift
+++ b/Tests/LLVMTests/ModuleMetadataSpec.swift
@@ -1,0 +1,67 @@
+import LLVM
+import XCTest
+import FileCheck
+import Foundation
+
+class ModuleMetadataSpec : XCTestCase {
+  func testAddModuleFlags() {
+    XCTAssertTrue(fileCheckOutput(of: .stderr, withPrefixes: ["MODULE-FLAGS"]) {
+      // MODULE-FLAGS: ; ModuleID = 'ModuleFlagsTest'
+      let module = Module(name: "ModuleFlagsTest")
+      // MODULE-FLAGS: !llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+
+      // MODULE-FLAGS:      !0 = !{i32 [[ERRVAL:\d+]], !"error", i32 [[ERRVAL]]}
+      module.addFlag(named: "error", constant: IntType.int32.constant(1), behavior: .error)
+      // MODULE-FLAGS-NEXT: !1 = !{i32 [[WARNVAL:\d+]], !"warning", i32 [[WARNVAL]]}
+      module.addFlag(named: "warning", constant: IntType.int32.constant(2), behavior: .warning)
+      // MODULE-FLAGS-NEXT: !2 = !{i32 [[REQUIREVAL:\d+]], !"require", i32 [[REQUIREVAL]]}
+      module.addFlag(named: "require", constant: IntType.int32.constant(3), behavior: .require)
+      // MODULE-FLAGS-NEXT: !3 = !{i32 [[OVERRIDEVAL:\d+]], !"override", i32 [[OVERRIDEVAL]]}
+      module.addFlag(named: "override", constant: IntType.int32.constant(4), behavior: .override)
+      // MODULE-FLAGS-NEXT: !4 = !{i32 [[APPVAL:\d+]], !"append", i32 [[APPVAL]]}
+      module.addFlag(named: "append", constant: IntType.int32.constant(5), behavior: .append)
+      // MODULE-FLAGS-NEXT: !5 = !{i32 [[APPUNIQVAL:\d+]], !"appendUnique", i32 [[APPUNIQVAL]]}
+      module.addFlag(named: "appendUnique", constant: IntType.int32.constant(6), behavior: .appendUnique)
+
+      module.dump()
+    })
+  }
+
+  func testModuleRetrieveFlags() {
+    let module = Module(name: "ModuleFlagsTest")
+    module.addFlag(named: "error", constant: IntType.int32.constant(1), behavior: .error)
+    module.addFlag(named: "warning", constant: IntType.int32.constant(2), behavior: .warning)
+    module.addFlag(named: "require", constant: IntType.int32.constant(3), behavior: .require)
+    module.addFlag(named: "override", constant: IntType.int32.constant(4), behavior: .override)
+    module.addFlag(named: "append", constant: IntType.int32.constant(5), behavior: .append)
+    module.addFlag(named: "appendUnique", constant: IntType.int32.constant(6), behavior: .appendUnique)
+
+    guard let flags = module.flags else {
+      XCTFail()
+      return
+    }
+
+    XCTAssertEqual(flags.count, 6)
+
+    XCTAssertEqual(flags[0].behavior, .error)
+    XCTAssertEqual(flags[1].behavior, .warning)
+    XCTAssertEqual(flags[2].behavior, .require)
+    XCTAssertEqual(flags[3].behavior, .override)
+    XCTAssertEqual(flags[4].behavior, .append)
+    XCTAssertEqual(flags[5].behavior, .appendUnique)
+
+    XCTAssertEqual(flags[0].key, "error")
+    XCTAssertEqual(flags[1].key, "warning")
+    XCTAssertEqual(flags[2].key, "require")
+    XCTAssertEqual(flags[3].key, "override")
+    XCTAssertEqual(flags[4].key, "append")
+    XCTAssertEqual(flags[5].key, "appendUnique")
+  }
+
+  #if !os(macOS)
+  static var allTests = testCase([
+    ("testAddModuleFlags", testAddModuleFlags),
+    ("testModuleRetrieveFlags", testModuleRetrieveFlags),
+  ])
+  #endif
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -14,5 +14,6 @@ XCTMain([
   // FIXME: These tests cannot run on Linux without SEGFAULT'ing.
   // JITSpec.allTests,
   ModuleLinkSpec.allTests,
+  ModuleMetadataSpec.allTests,
 ])
 #endif


### PR DESCRIPTION
- Improve Alias bindings
- Add missing optimization pass
- Add bindings for module flag entries.