### PR TITLE
Modify return type of main function

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ let builder = IRBuilder(module: module)
 let main = builder.addFunction(
              "main",
              type: FunctionType(argTypes: [],
-             returnType: VoidType())
+             returnType: IntType.int64)
            )
 let entry = main.appendBasicBlock(named: "entry")
 builder.positionAtEnd(of: entry)
@@ -42,7 +42,7 @@ This simple program generates the following IR:
 ```llvm
 // module.dump()
 
-define void @main() {
+define i64 @main() {
 entry:
   ret i64 42
 }


### PR DESCRIPTION
We can't compile sample LLVM IR on README.

```ll
define void @main() {
entry:
  ret i64 42
}
```

```console
$ lli main.ll
lli: main.ll:3:7: error: value doesn't match function result type 'void'
  ret i64 42
      ^
```

main function must return `i64` instead of `void`.

```ll
define i64 @main() {
entry:
  ret i64 42
}
```