### PR TITLE
Overhaul ObjectFile

### DIFF
--- a/Sources/llvmshims/include/shim.h
+++ b/Sources/llvmshims/include/shim.h
@@ -57,10 +57,10 @@ typedef enum {
 typedef struct LLVMOpaqueBinary *LLVMBinaryRef;
 
 LLVMBinaryType LLVMBinaryGetType(LLVMBinaryRef BR);
-LLVMBinaryRef LLVMCreateBinary(LLVMMemoryBufferRef MemBuf, LLVMContextRef Context);
+LLVMBinaryRef LLVMCreateBinary(LLVMMemoryBufferRef MemBuf, LLVMContextRef Context, char **ErrorMessage);
 void LLVMDisposeBinary(LLVMBinaryRef BR);
 
-LLVMBinaryRef LLVMUniversalBinaryGetObjectForArchitecture(LLVMBinaryRef BR, const char *Arch, size_t ArchLen);
+LLVMBinaryRef LLVMUniversalBinaryCopyObjectForArchitecture(LLVMBinaryRef BR, const char *Arch, size_t ArchLen, char **ErrorMessage);
 
 LLVMSectionIteratorRef LLVMObjectFileGetSections(LLVMBinaryRef BR);
 


### PR DESCRIPTION
Add a new superclass for generic binary files.  Specialize it by the
existing generic ObjectFile class and a new MachOUniversalBinaryFile
class.

Refine failable initializers into throwing initializers (we're backed by
llvm::Expected, so we can never error and get null at the same time).