### PR TITLE
Introduce IRInstruction

### DIFF
--- a/Sources/LLVM/AttachedMetadata.swift
+++ b/Sources/LLVM/AttachedMetadata.swift
@@ -52,7 +52,7 @@ extension IRGlobal {
   }
 }
 
-extension Instruction {
+extension IRInstruction {
   /// Retrieves all metadata entries attached to this instruction.
   public var metadata: AttachedMetadata {
     var count = 0

--- a/Sources/LLVM/BasicBlock.swift
+++ b/Sources/LLVM/BasicBlock.swift
@@ -61,13 +61,13 @@ public struct BasicBlock: IRValue {
   }
 
   /// Returns the first instruction in the basic block, if it exists.
-  public var firstInstruction: Instruction? {
+  public var firstInstruction: IRInstruction? {
     guard let val = LLVMGetFirstInstruction(llvm) else { return nil }
     return Instruction(llvm: val)
   }
 
   /// Returns the first instruction in the basic block, if it exists.
-  public var lastInstruction: Instruction? {
+  public var lastInstruction: IRInstruction? {
     guard let val = LLVMGetLastInstruction(llvm) else { return nil }
     return Instruction(llvm: val)
   }
@@ -98,10 +98,10 @@ public struct BasicBlock: IRValue {
   }
 
   /// Returns a sequence of the Instructions that make up this basic block.
-  public var instructions: AnySequence<Instruction> {
+  public var instructions: AnySequence<IRInstruction> {
     var current = firstInstruction
-    return AnySequence<Instruction> {
-      return AnyIterator<Instruction> {
+    return AnySequence<IRInstruction> {
+      return AnyIterator<IRInstruction> {
         defer { current = current?.next() }
         return current
       }

--- a/Sources/LLVM/Call.swift
+++ b/Sources/LLVM/Call.swift
@@ -3,7 +3,7 @@ import cllvm
 #endif
 
 /// Represents a simple function call.
-public struct Call: IRValue {
+public struct Call: IRInstruction {
   let llvm: LLVMValueRef
 
   /// Retrieves the underlying LLVM value object.
@@ -43,7 +43,7 @@ public struct Call: IRValue {
 }
 
 /// Represents a function call that may transfer control to an exception handler.
-public struct Invoke: IRValue {
+public struct Invoke: IRInstruction {
   let llvm: LLVMValueRef
 
   /// Retrieves the underlying LLVM value object.

--- a/Sources/LLVM/DIBuilder.swift
+++ b/Sources/LLVM/DIBuilder.swift
@@ -65,7 +65,7 @@ extension DIBuilder {
   ///   - location: The location of the variable in source.
   public func buildDeclare(
     of variable: IRValue,
-    before: Instruction,
+    before: IRInstruction,
     metadata: LocalVariableMetadata,
     expr: ExpressionMetadata,
     location: DebugLocation
@@ -133,7 +133,7 @@ extension DIBuilder {
   public func buildDbgValue(
     of value: IRValue,
     to metadata: LocalVariableMetadata,
-    before: Instruction,
+    before: IRInstruction,
     expr: ExpressionMetadata,
     location: DebugLocation
   ) {

--- a/Sources/LLVM/IRValue.swift
+++ b/Sources/LLVM/IRValue.swift
@@ -20,6 +20,11 @@ public extension IRValue {
     return LLVMIsConstant(asLLVM()) != 0
   }
 
+  /// Returns whether this value is an instruction.
+  var isInstruction: Bool {
+    return LLVMIsAInstruction(asLLVM()) != nil
+  }
+
   /// Returns whether this value has been initialized with the special `undef`
   /// value.
   ///
@@ -150,6 +155,12 @@ extension LLVMValueRef: IRValue {
     return self
   }
 }
+
+// N.B. This conformance is strictly not correct, but LLVM-C chooses to muddy
+// the difference between LLVMValueRef and a number of what should be refined
+// types.  What matters is that we verify any returned `IRInstruction` values
+// are actually instructions.
+extension LLVMValueRef: IRInstruction {}
 
 extension Int: IRValue {
   /// Retrieves the underlying LLVM value object.

--- a/Sources/LLVM/OpCode.swift
+++ b/Sources/LLVM/OpCode.swift
@@ -3,7 +3,7 @@ import cllvm
 #endif
 
 /// Enumerates the opcodes of instructions available in the LLVM IR language.
-public enum OpCode {
+public enum OpCode: CaseIterable {
   // MARK: Terminator Instructions
 
   /// The opcode for the `ret` instruction.
@@ -230,7 +230,7 @@ public enum OpCode {
 
 extension OpCode {
   /// `BinaryOperation` enumerates the subset of opcodes that are binary operations.
-  public enum Binary {
+  public enum Binary: CaseIterable {
     /// The `add` instruction.
     case add
     /// The `fadd` instruction.
@@ -281,10 +281,15 @@ extension OpCode {
     public var llvm: LLVMOpcode {
       return Binary.binaryOperationMap[self]!
     }
+
+    /// Retrieves the corresponding opcode for this binary operation.
+    public var opCode: OpCode {
+      return OpCode(rawValue: self.llvm)
+    }
   }
 
   /// `CastOperation` enumerates the subset of opcodes that are cast operations.
-  public enum Cast {
+  public enum Cast: CaseIterable {
     /// The `trunc` instruction.
     case trunc
     /// The `zext` instruction.
@@ -331,6 +336,11 @@ extension OpCode {
     /// Retrieves the corresponding `LLVMOpcode`.
     public var llvm: LLVMOpcode {
       return Cast.castOperationMap[self]!
+    }
+
+    /// Retrieves the corresponding opcode for this cast operation.
+    public var opCode: OpCode {
+      return OpCode(rawValue: self.llvm)
     }
   }
 }

--- a/Sources/LLVM/PhiNode.swift
+++ b/Sources/LLVM/PhiNode.swift
@@ -32,7 +32,7 @@ import cllvm
 ///
 /// If the flow of control reaches `aCondTrue`, the value of `b` is `2`, else it
 /// is `1` and SSA semantics are preserved.
-public struct PhiNode: IRValue {
+public struct PhiNode: IRInstruction {
   internal let llvm: LLVMValueRef
 
   /// Adds a list of incoming value and their associated basic blocks to the end

--- a/Sources/LLVM/Switch.swift
+++ b/Sources/LLVM/Switch.swift
@@ -6,7 +6,7 @@ import cllvm
 /// defines a jump table of values and destination basic blocks to pass the flow
 /// of control to if a condition value matches.  If no match is made, control
 /// flow passes to the default basic block.
-public struct Switch: IRValue {
+public struct Switch: IRInstruction {
   internal let llvm: LLVMValueRef
 
   /// Inserts a case with the given value and destination basic block in the

--- a/Tests/LLVMTests/IRInstructionSpec.swift
+++ b/Tests/LLVMTests/IRInstructionSpec.swift
@@ -1,0 +1,123 @@
+import LLVM
+import XCTest
+import FileCheck
+import Foundation
+import cllvm
+
+class IRInstructionSpec : XCTestCase {
+  func testInstructionOpCodes() {
+    // N.B. This module does not have to be well-formed.
+    let module = Module(name: "IRInstructionTest")
+    let builder = IRBuilder(module: module)
+
+    let structTy = StructType(elementTypes: [
+      IntType.int32
+    ])
+    let global = module.addGlobal("type_info", type: structTy)
+
+    let f = module.addFunction("test",
+                               type: FunctionType(argTypes: [
+                                  IntType.int1,
+                                  FloatType.float,
+                                  PointerType.toVoid,
+                                  structTy,
+                                  VectorType(elementType: IntType.int32, count: 42),
+                                ], returnType: VoidType()))
+    let entry = f.appendBasicBlock(named: "entry")
+    let landing = f.appendBasicBlock(named: "landing")
+    builder.positionAtEnd(of: landing)
+    let land = builder.buildLandingPad(returning: VoidType(), clauses: [
+      LandingPadClause.catch(global)
+    ])
+    builder.buildRet(land)
+    
+    builder.positionAtEnd(of: entry)
+
+    // Use parameter values to guaranteed constant folding is off.
+    let ival = f.parameters[0]
+    let fval = f.parameters[1]
+    let pval = f.parameters[2]
+    let sval = f.parameters[3]
+    let vval = f.parameters[4]
+    for op in OpCode.Binary.allCases {
+      let opVal = builder.buildBinaryOperation(op, ival, ival) as! IRInstruction
+      XCTAssertTrue(opVal.isAInstruction)
+      XCTAssertEqual(opVal.opCode, opVal.opCode)
+    }
+
+    for op in OpCode.Cast.allCases {
+      let opVal = builder.buildCast(op, value: fval, type: PointerType.toVoid) as! IRInstruction
+      XCTAssertTrue(opVal.isAInstruction)
+      XCTAssertEqual(opVal.opCode, opVal.opCode)
+    }
+
+    XCTAssertEqual((builder.buildPointerCast(of: pval, to: PointerType(pointee: IntType.int1)) as! IRInstruction).opCode, OpCode.bitCast)
+    XCTAssertEqual((builder.buildIntCast(of: ival, to: IntType.int32, signed: false) as! IRInstruction).opCode, OpCode.zext)
+    XCTAssertEqual((builder.buildIntCast(of: ival, to: IntType.int32, signed: true) as! IRInstruction).opCode, OpCode.sext)
+    XCTAssertEqual((builder.buildNeg(ival) as! IRInstruction).opCode, OpCode.sub)
+    XCTAssertEqual((builder.buildAdd(ival, ival) as! IRInstruction).opCode, OpCode.add)
+    XCTAssertEqual((builder.buildSub(ival, ival) as! IRInstruction).opCode, OpCode.sub)
+    XCTAssertEqual((builder.buildAdd(fval, fval) as! IRInstruction).opCode, OpCode.fadd)
+    XCTAssertEqual((builder.buildSub(fval, fval) as! IRInstruction).opCode, OpCode.fsub)
+    XCTAssertEqual((builder.buildMul(ival, ival) as! IRInstruction).opCode, OpCode.mul)
+    XCTAssertEqual((builder.buildRem(ival, ival, signed: false) as! IRInstruction).opCode, OpCode.urem)
+    XCTAssertEqual((builder.buildRem(ival, ival, signed: true) as! IRInstruction).opCode, OpCode.srem)
+    XCTAssertEqual((builder.buildDiv(ival, ival, signed: false) as! IRInstruction).opCode, OpCode.udiv)
+    XCTAssertEqual((builder.buildDiv(ival, ival, signed: true) as! IRInstruction).opCode, OpCode.sdiv)
+    XCTAssertEqual((builder.buildICmp(ival, ival, .equal) as! IRInstruction).opCode, OpCode.icmp)
+    XCTAssertEqual((builder.buildFCmp(fval, fval, .orderedEqual) as! IRInstruction).opCode, OpCode.fcmp)
+    XCTAssertEqual((builder.buildNot(ival) as! IRInstruction).opCode, OpCode.xor)
+    XCTAssertEqual((builder.buildXor(ival, ival) as! IRInstruction).opCode, OpCode.xor)
+    XCTAssertEqual((builder.buildOr(ival, ival) as! IRInstruction).opCode, OpCode.or)
+    XCTAssertEqual((builder.buildAnd(ival, ival) as! IRInstruction).opCode, OpCode.and)
+    XCTAssertEqual((builder.buildShl(ival, ival) as! IRInstruction).opCode, OpCode.shl)
+    XCTAssertEqual((builder.buildShr(ival, ival, isArithmetic: false) as! IRInstruction).opCode, OpCode.lshr)
+    XCTAssertEqual((builder.buildShr(ival, ival, isArithmetic: true) as! IRInstruction).opCode, OpCode.ashr)
+    XCTAssertEqual(builder.buildPhi(IntType.int1).opCode, OpCode.phi)
+    XCTAssertEqual(builder.buildSelect(ival, then: ival, else: ival).opCode, OpCode.select)
+    XCTAssertEqual(builder.buildSwitch(ival, else: entry, caseCount: 0).opCode, OpCode.switch)
+    XCTAssertEqual(builder.buildCondBr(condition: ival, then: entry, else: entry).opCode, OpCode.br)
+    XCTAssertEqual(builder.buildBr(entry).opCode, OpCode.br)
+    XCTAssertEqual(builder.buildIndirectBr(address: f.address(of: entry)!, destinations: []).opCode, OpCode.indirectBr)
+    XCTAssertEqual(builder.buildUnreachable().opCode, OpCode.unreachable)
+    XCTAssertEqual(builder.buildCall(f, args: [ival, fval, pval]).opCode, OpCode.call)
+    XCTAssertEqual(builder.buildInvoke(f, args: [], next: entry, catch: landing).opCode, OpCode.invoke)
+    XCTAssertEqual(builder.buildLandingPad(returning: VoidType(), clauses: [
+      LandingPadClause.catch(global)
+    ]).opCode, OpCode.landingPad)
+    XCTAssertEqual((builder.buildResume(ival) as! IRInstruction).opCode, OpCode.resume)
+    XCTAssertEqual((builder.buildVAArg(pval, type: PointerType.toVoid) as! IRInstruction).opCode, OpCode.vaArg)
+    XCTAssertEqual(builder.buildAlloca(type: IntType.int1).opCode, OpCode.alloca)
+    XCTAssertEqual(builder.buildStore(ival, to: pval).opCode, OpCode.store)
+    XCTAssertEqual(builder.buildLoad(pval).opCode, OpCode.load)
+    XCTAssertEqual((builder.buildInBoundsGEP(pval, indices: []) as! IRInstruction).opCode, OpCode.getElementPtr)
+    XCTAssertEqual((builder.buildGEP(pval, indices: []) as! IRInstruction).opCode, OpCode.getElementPtr)
+    XCTAssertEqual((builder.buildExtractValue(sval, index: 0) as! IRInstruction).opCode, OpCode.extractValue)
+    XCTAssertEqual((builder.buildTrunc(ival, type: IntType.int32) as! IRInstruction).opCode, OpCode.trunc)
+    XCTAssertEqual((builder.buildSExt(ival, type: IntType.int32) as! IRInstruction).opCode, OpCode.sext)
+    XCTAssertEqual((builder.buildZExt(ival, type: IntType.int32) as! IRInstruction).opCode, OpCode.zext)
+    XCTAssertEqual((builder.buildIntToPtr(ival, type: PointerType.toVoid) as! IRInstruction).opCode, OpCode.intToPtr)
+    XCTAssertEqual((builder.buildPtrToInt(pval, type: IntType.int32) as! IRInstruction).opCode, OpCode.ptrToInt)
+    XCTAssertEqual(builder.buildFence(ordering: .acquire).opCode, OpCode.fence)
+    XCTAssertEqual((builder.buildAtomicCmpXchg(ptr: pval, of: ival, to: ival, successOrdering: .acquire, failureOrdering: .acquire) as! IRInstruction).opCode, OpCode.atomicCmpXchg)
+    XCTAssertEqual((builder.buildAtomicRMW(atomicOp: .add, ptr: pval, value: ival, ordering: .acquire) as! IRInstruction).opCode, OpCode.atomicRMW)
+    XCTAssertEqual(builder.buildMalloc(IntType.int64).opCode, OpCode.bitCast) // malloc-bitcast pair
+    XCTAssertEqual(builder.buildFree(pval).opCode, OpCode.call)
+    XCTAssertEqual(builder.buildMemset(to: pval, of: ival, length: 1, alignment: .one).opCode, OpCode.call)
+    XCTAssertEqual(builder.buildMemCpy(to: pval, .one, from: pval, .one, length: 1).opCode, OpCode.call)
+    XCTAssertEqual(builder.buildMemMove(to: pval, .one, from: pval, .one, length: 1).opCode, OpCode.call)
+    XCTAssertEqual((builder.buildInsertValue(aggregate: sval, element: ival, index: 0) as! IRInstruction).opCode, OpCode.insertValue)
+    XCTAssertEqual((builder.buildExtractValue(sval, index: 0) as! IRInstruction).opCode, OpCode.extractValue)
+    XCTAssertEqual((builder.buildInsertElement(vector: vval, element: 0, index: 0) as! IRInstruction).opCode, OpCode.insertElement)
+    XCTAssertEqual((builder.buildExtractElement(vector: vval, index: 0) as! IRInstruction).opCode, OpCode.extractElement)
+    let mask = VectorType(elementType: IntType.int32, count: 1).undef()
+    XCTAssertEqual((builder.buildShuffleVector(vval, and: ival, mask: mask) as! IRInstruction).opCode, OpCode.shuffleVector)
+    XCTAssertEqual(builder.buildRetVoid().opCode, OpCode.ret)
+  }
+
+  #if !os(macOS)
+  static var allTests = testCase([
+    ("testInstructionOpCodes", testInstructionOpCodes),
+  ])
+  #endif
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -13,6 +13,7 @@ XCTMain([
   IRExceptionSpec.allTests,
   IRGlobalSpec.allTests,
   IRIntrinsicSpec.allTests,
+  IRInstructionSpec.allTests,
   IRMetadataSpec.allTests,
   IROperationSpec.allTests,
   JITSpec.allTests,


### PR DESCRIPTION
In order to unify the many structures we have that each represent instruction values, introduce the IRInstruction protocol.  LLVMValueRef now unconditionally conforms to IRInstruction to facilitate dynamic casts.  Note that this is strictly not correct.  In particular, constant folding means the result of a lot of IRBuilder calls wind up as just plain values.  Therefore, the return types for IRBuilder functions has only been refined in as many places where we can guarantee constant-folding will always produce an instruction or instruction sequence.

Ultimately, this protocol greases the wheels for a more robust AttachedMetadata API for which we need new shims.