### PR TITLE
Remove extraneous labels from FunctionType

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@ Defining a function and moving the cursor to a point where we can begin insertin
 ```swift
 let builder = IRBuilder(module: module)
 
-let main = builder.addFunction(
-             "main",
-             type: FunctionType(argTypes: [],
-             returnType: IntType.int64)
-           )
+let main = builder.addFunction("main",
+                               type: FunctionType([], IntType.int64))
 let entry = main.appendBasicBlock(named: "entry")
 builder.positionAtEnd(of: entry)
 ```
@@ -95,11 +92,9 @@ func calculateFibs(_ backward : Bool) -> Double {
 Notice that the value of `retVal` depends on the path the flow of control takes through this program, so we must emit a PHI node to properly initialize it:
 
 ```swift
-let function = builder.addFunction(
-                 "calculateFibs", 
-                 type: FunctionType(argTypes: [IntType.int1], 
-                 returnType: FloatType.double)
-               )
+let function = builder.addFunction("calculateFibs", 
+                                   type: FunctionType([IntType.int1], 
+                                                      FloatType.double))
 let entryBB = function.appendBasicBlock(named: "entry")
 builder.positionAtEnd(of: entryBB)
 

--- a/Sources/LLVM/BasicBlock.swift
+++ b/Sources/LLVM/BasicBlock.swift
@@ -24,8 +24,7 @@ import cllvm
 ///
 ///     let module = Module(name: "Example")
 ///     let fun = builder.addFunction("example",
-///                                   type: FunctionType(argTypes: [],
-///                                                      returnType: VoidType()))
+///                                   type: FunctionType([], VoidType()))
 ///
 ///     // This basic block is "floating" outside of a function.
 ///     let floatingBB = BasicBlock(name: "floating")
@@ -37,8 +36,7 @@ import cllvm
 ///
 ///     let module = Module(name: "Example")
 ///     let fun = builder.addFunction("example",
-///                                   type: FunctionType(argTypes: [],
-///                                                      returnType: VoidType()))
+///                                   type: FunctionType([], VoidType()))
 ///
 ///     // This basic block is "attached" to the example function.
 ///     let attachedBB = fun.appendBasicBlock(named: "attached")

--- a/Sources/LLVM/Function.swift
+++ b/Sources/LLVM/Function.swift
@@ -22,8 +22,7 @@ import llvmshims
 ///     let module = Module(name: "Example")
 ///     let builder = IRBuilder(module: module)
 ///     let fun = builder.addFunction("example",
-///                                   type: FunctionType(argTypes: [],
-///                                                      returnType: VoidType()))
+///                                   type: FunctionType([], VoidType()))
 ///     // Create and append the entry block
 ///     let entryBB = fun.appendBasicBlock(named: "entry")
 ///     // Create and append a standalone basic block
@@ -46,8 +45,7 @@ import llvmshims
 ///     let module = Module(name: "Example")
 ///     let builder = IRBuilder(module: module)
 ///     let fun = builder.addFunction("example",
-///                                   type: FunctionType(argTypes: [],
-///                                                      returnType: VoidType()))
+///                                   type: FunctionType([], VoidType()))
 ///     // Switch to swiftcc
 ///     fun.callingConvention = .swift
 ///
@@ -70,8 +68,7 @@ import llvmshims
 ///     let module = Module(name: "Example")
 ///     let builder = IRBuilder(module: module)
 ///     let fun = builder.addFunction("example",
-///                                   type: FunctionType(argTypes: [],
-///                                                      returnType: VoidType()))
+///                                   type: FunctionType([], VoidType()))
 ///     // Attach the metadata
 ///     fun.addMetadata(hotAttr, kind: .sectionPrefix)
 ///

--- a/Sources/LLVM/FunctionType.swift
+++ b/Sources/LLVM/FunctionType.swift
@@ -8,11 +8,11 @@ import cllvm
 /// and `MetadataType`.
 public struct FunctionType: IRType {
   /// The list of argument types.
-  public let argTypes: [IRType]
+  public let parameterTypes: [IRType]
   /// The return type of this function type.
   public let returnType: IRType
   /// Returns whether this function is variadic.
-  public let isVarArg: Bool
+  public let isVariadic: Bool
 
   /// Creates a function type with the given argument types and return type.
   ///
@@ -21,21 +21,55 @@ public struct FunctionType: IRType {
   /// - parameter isVarArg: Indicates whether this function type is variadic.
   ///   Defaults to `false`.
   /// - note: The context of this type is taken from it's `returnType`
+  @available(*, deprecated, message: "Use the more concise initializer instead")
   public init(argTypes: [IRType], returnType: IRType, isVarArg: Bool = false) {
-    self.argTypes = argTypes
+    self.parameterTypes = argTypes
     self.returnType = returnType
-    self.isVarArg = isVarArg
+    self.isVariadic = isVarArg
+  }
+
+  /// Creates a function type with the given argument types and return type.
+  ///
+  /// - parameter parameterTypes: A list of the argument types of the function
+  ///   type.
+  /// - parameter returnType: The return type of the function type.
+  /// - parameter variadic: Indicates whether this function type is variadic.
+  ///   Defaults to `false`.
+  /// - note: The context of this type is taken from it's `returnType`
+  public init(
+    _ parameterTypes: [IRType],
+    _ returnType: IRType,
+    variadic: Bool = false
+  ) {
+    self.parameterTypes = parameterTypes
+    self.returnType = returnType
+    self.isVariadic = variadic
   }
 
   /// Retrieves the underlying LLVM type object.
   public func asLLVM() -> LLVMTypeRef {
-    var argIRTypes = argTypes.map { $0.asLLVM() as Optional }
+    var argIRTypes = parameterTypes.map { $0.asLLVM() as Optional }
     return argIRTypes.withUnsafeMutableBufferPointer { buf in
       return LLVMFunctionType(returnType.asLLVM(),
                               buf.baseAddress,
                               UInt32(buf.count),
-                              isVarArg.llvm)!
+                              isVariadic.llvm)!
     }
+  }
+}
+
+// MARK: Legacy Accessors
+
+extension FunctionType {
+  /// The list of argument types.
+  @available(*, deprecated, message: "Use FunctionType.parameterTypes instead")
+  public var argTypes: [IRType] {
+    return self.parameterTypes
+  }
+  /// Returns whether this function is variadic.
+  @available(*, deprecated, message: "Use FunctionType.isVariadic instead")
+  public var isVarArg: Bool {
+    return self.isVariadic
   }
 }
 

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -71,10 +71,10 @@ import llvmshims
 ///     let module = Module(name: "Example")
 ///     let builder = IRBuilder(module: module)
 ///     let fun = builder.addFunction("test",
-///                                   type: FunctionType(argTypes: [
+///                                   type: FunctionType([
 ///                                           IntType.int8,
 ///                                           IntType.int8,
-///                                   ], returnType: FloatType.float))
+///                                   ], FloatType.float))
 ///     let entry = fun.appendBasicBlock(named: "entry")
 ///     // Set the insertion point to the entry block of this function
 ///     builder.positionAtEnd(of: entry)
@@ -99,11 +99,11 @@ import llvmshims
 ///     let module = Module(name: "Example")
 ///     let builder = IRBuilder(module: module)
 ///     let select = builder.addFunction("select",
-///                                      type: FunctionType(argTypes: [
+///                                      type: FunctionType([
 ///                                              IntType.int1,
 ///                                              FloatType.float,
 ///                                              FloatType.float,
-///                                      ], returnType: FloatType.float))
+///                                      ], FloatType.float))
 ///     let entry = select.appendBasicBlock(named: "entry")
 ///     builder.positionAtEnd(of: entry)
 ///

--- a/Sources/LLVM/IRType.swift
+++ b/Sources/LLVM/IRType.swift
@@ -71,7 +71,7 @@ internal func convertType(_ type: LLVMTypeRef) -> IRType {
     }
     let ret = convertType(LLVMGetReturnType(type))
     let isVarArg = LLVMIsFunctionVarArg(type) != 0
-    return FunctionType(argTypes: params, returnType: ret, isVarArg: isVarArg)
+    return FunctionType(params, ret, variadic: isVarArg)
   case LLVMStructTypeKind:
     return StructType(llvm: type)
   case LLVMArrayTypeKind:

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -22,8 +22,7 @@ import cllvm
 ///     let module = Module(name: "Example")
 ///     let builder = IRBuilder(module: module)
 ///     let main = builder.addFunction("main",
-///                                    type: FunctionType(argTypes: [],
-///                                                       returnType: VoidType()))
+///                                    type: FunctionType([], VoidType()))
 ///     let entry = main.appendBasicBlock(named: "entry")
 ///     builder.positionAtEnd(of: entry)
 ///     builder.buildRet(main.address(of: entry)!)

--- a/Tests/LLVMTests/APIntSpec.swift
+++ b/Tests/LLVMTests/APIntSpec.swift
@@ -294,8 +294,7 @@ class APIntSpec : XCTestCase {
       let intType = IntType(width: 420)
       // ARBITRARY: define i420 @test() {
       let main = builder.addFunction("test",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: intType))
+                                     type: FunctionType([], intType))
       // ARBITRARY-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)

--- a/Tests/LLVMTests/BFC.swift
+++ b/Tests/LLVMTests/BFC.swift
@@ -153,11 +153,11 @@ private enum Externs {
     switch self {
     case .getchar:
       let f = builder.addFunction("readchar",
-                                  type: FunctionType(argTypes: [],
-                                                     returnType: cellType))
+                                  type: FunctionType([],
+                                                     cellType))
       let getCharExtern = builder.addFunction("getchar",
-                                              type: FunctionType(argTypes: [],
-                                                                 returnType: cellType))
+                                              type: FunctionType([],
+                                                                 cellType))
       let entry = f.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
       let charValue = builder.buildCall(getCharExtern, args: [])
@@ -167,19 +167,18 @@ private enum Externs {
       return f
     case .putchar:
       return builder.addFunction("putchar",
-                                 type: FunctionType(argTypes: [
-                                    cellType
-                                 ], returnType: VoidType()))
+                                 type: FunctionType([
+                                   cellType
+                                 ], VoidType()))
     case .flush:
       let f = builder.addFunction("flush",
-                                  type: FunctionType(argTypes: [],
-                                                     returnType: VoidType()))
+                                  type: FunctionType([], VoidType()))
       let entry = f.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
       let ptrTy = PointerType(pointee: IntType.int8)
       let fflushExtern = builder.addFunction("fflush",
-                                             type: FunctionType(argTypes: [ ptrTy ],
-                                                                returnType: IntType.int32))
+                                             type: FunctionType([ ptrTy ],
+                                                                IntType.int32))
       _ = builder.buildCall(fflushExtern, args: [ ptrTy.constPointerNull() ])
       builder.buildRetVoid()
       return f
@@ -194,8 +193,8 @@ private func compile(at column: Int = #column, line: Int = #line, _ program: Str
   let cellTape = module.addGlobal("tape", initializer: cellTapeType.null())
 
   let main = builder.addFunction("main",
-                                 type: FunctionType(argTypes: [],
-                                                    returnType: IntType.int32))
+                                 type: FunctionType([],
+                                                    IntType.int32))
 
   let sourceFile = #file.components(separatedBy: "/").last!
   let sourceDir = #file.components(separatedBy: "/").dropLast().joined(separator: "/")

--- a/Tests/LLVMTests/ConstantSpec.swift
+++ b/Tests/LLVMTests/ConstantSpec.swift
@@ -12,8 +12,7 @@ class ConstantSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // SIGNEDCONST: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       let constant = IntType.int64.constant(42)
 
       // SIGNEDCONST-NEXT: entry:
@@ -42,8 +41,7 @@ class ConstantSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // UNSIGNEDCONST: define i64 @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int64))
+                                     type: FunctionType([], IntType.int64))
       let constant = IntType.int64.constant(UInt64(42))
 
       // UNSIGNEDCONST-NEXT: entry:
@@ -70,8 +68,7 @@ class ConstantSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // FLOATINGCONST: define i64 @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int64))
+                                     type: FunctionType([], IntType.int64))
       let constant = FloatType.double.constant(42.0)
 
       // FLOATINGCONST-NEXT: entry:
@@ -98,8 +95,7 @@ class ConstantSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // STRUCTCONST: define i64 @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int64))
+                                     type: FunctionType([], IntType.int64))
 
       let constant = StructType(elementTypes: [IntType.int64])
         .constant(values: [42])
@@ -121,8 +117,7 @@ class ConstantSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // STRUCTCONSTGETELEMENT: define i64 @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int64))
+                                     type: FunctionType([], IntType.int64))
 
       let constant = StructType(elementTypes: [IntType.int64])
         .constant(values: [42])
@@ -148,8 +143,7 @@ class ConstantSpec : XCTestCase {
       let vecTy = VectorType(elementType: IntType.int32, count: 4)
       // VECTORCONSTSHUFFLE-IDENTITY: define <4 x i32> @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: vecTy))
+                                     type: FunctionType([], vecTy))
 
       let vec1 = vecTy.constant([ 1, 2, 3, 4 ] as [Int32])
       let mask = vecTy.constant([ 0, 1, 2, 3 ] as [Int32])
@@ -175,8 +169,7 @@ class ConstantSpec : XCTestCase {
       let maskTy = VectorType(elementType: IntType.int32, count: 8)
       // VECTORCONSTSHUFFLE: define <8 x i32> @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: maskTy))
+                                     type: FunctionType([], maskTy))
 
       let vecTy = VectorType(elementType: IntType.int32, count: 4)
       let vec1 = vecTy.constant([ 1, 2, 3, 4 ] as [Int32])

--- a/Tests/LLVMTests/DIBuilderSpec.swift
+++ b/Tests/LLVMTests/DIBuilderSpec.swift
@@ -12,7 +12,7 @@ class DIBuilderSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       let debugBuilder = DIBuilder(module: module)
 
-      let f = builder.addFunction("foo", type: FunctionType(argTypes: [], returnType: VoidType()))
+      let f = builder.addFunction("foo", type: FunctionType([], VoidType()))
       let bb = f.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: bb)
       _ = builder.buildAlloca(type: IntType.int8)

--- a/Tests/LLVMTests/IRAttributesSpec.swift
+++ b/Tests/LLVMTests/IRAttributesSpec.swift
@@ -11,8 +11,8 @@ class IRAttributesSpec : XCTestCase {
       let module = Module(name: "IRBuilderTest")
       let builder = IRBuilder(module: module)
       let fn = builder.addFunction("fn",
-                                   type: FunctionType(argTypes: [IntType.int32, IntType.int32],
-                                                      returnType: IntType.int32))
+                                   type: FunctionType([IntType.int32, IntType.int32],
+                                                      IntType.int32))
 
       // FNATTR: define i32 @fn(i32, i32) #0 {
       fn.addAttribute(.nounwind, to: .function)
@@ -33,8 +33,8 @@ class IRAttributesSpec : XCTestCase {
       let module = Module(name: "IRBuilderTest")
       let builder = IRBuilder(module: module)
       let fn = builder.addFunction("fn",
-                                   type: FunctionType(argTypes: [IntType.int32, IntType.int32],
-                                                      returnType: IntType.int32))
+                                   type: FunctionType([IntType.int32, IntType.int32],
+                                                      IntType.int32))
 
       // RVATTR: define signext i32 @fn(i32, i32) {
       fn.addAttribute(.signext, to: .returnValue)
@@ -55,8 +55,8 @@ class IRAttributesSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       let i8ptr = PointerType(pointee: IntType.int8)
       let fn = builder.addFunction("fn",
-                                   type: FunctionType(argTypes: [IntType.int32, i8ptr],
-                                                      returnType: IntType.int32))
+                                   type: FunctionType([IntType.int32, i8ptr],
+                                                      IntType.int32))
 
       // ARGATTR: define i32 @fn(i32 zeroext, i8* align 8) {
       fn.addAttribute(.zeroext, to: .argument(0))
@@ -78,7 +78,7 @@ class IRAttributesSpec : XCTestCase {
 
     let i8ptr = PointerType(pointee: IntType.int8)
     let fn = builder.addFunction("fn",
-                                 type: FunctionType(argTypes: [i8ptr], returnType: i8ptr))
+                                 type: FunctionType([i8ptr], i8ptr))
 
     // MARK: Enum attributes
 
@@ -163,7 +163,7 @@ class IRAttributesSpec : XCTestCase {
 
     let i8ptr = PointerType(pointee: IntType.int8)
     let fn = builder.addFunction("fn",
-                                 type: FunctionType(argTypes: [i8ptr], returnType: i8ptr))
+                                 type: FunctionType([i8ptr], i8ptr))
 
     // MARK: Enum attributes
 

--- a/Tests/LLVMTests/IRBuilderSpec.swift
+++ b/Tests/LLVMTests/IRBuilderSpec.swift
@@ -12,8 +12,8 @@ class IRBuilderSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // IRBUILDER: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([],
+                                                        VoidType()))
       // IRBUILDER-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -44,12 +44,11 @@ class IRBuilderSpec : XCTestCase {
 
       // IRBUILDER-INLINE-ASM: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRBUILDER-INLINE-ASM-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
-      let ty = FunctionType(argTypes: [ PointerType(pointee: IntType.int32) ], returnType: VoidType())
+      let ty = FunctionType([ PointerType(pointee: IntType.int32) ], VoidType())
       let emptyASM = builder.buildInlineAssembly("", dialect: .att, type: ty, constraints: "=r,0", hasSideEffects: true, needsAlignedStack: true)
       // IRBUILDER-INLINE-ASM-NEXT: call void asm sideeffect alignstack "\00", "=r,0\00"(i32* @a)
       _ = builder.buildCall(emptyASM, args: [ g1 ])
@@ -82,8 +81,7 @@ class IRBuilderSpec : XCTestCase {
 
       // IRBUILDERARITH: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRBUILDERARITH-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -164,8 +162,7 @@ class IRBuilderSpec : XCTestCase {
 
       // IRBUILDERCMP: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRBUILDERCMP-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -218,8 +215,7 @@ class IRBuilderSpec : XCTestCase {
 
       // IRBUILDERFCMP: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRBUILDERFCMP-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -269,8 +265,7 @@ class IRBuilderSpec : XCTestCase {
 
       // CONTROLFLOW: define i32 @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int32))
+                                     type: FunctionType([], IntType.int32))
 
       // CONTROLFLOW-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
@@ -327,8 +322,8 @@ class IRBuilderSpec : XCTestCase {
 
         // CAST: define i32 @main() {
         let main = builder.addFunction("main",
-                                       type: FunctionType(argTypes: [],
-                                                          returnType: IntType.int32))
+                                       type: FunctionType([],
+                                                          IntType.int32))
 
         // CAST-NEXT: entry:
         let entry = main.appendBasicBlock(named: "entry")

--- a/Tests/LLVMTests/IRExceptionSpec.swift
+++ b/Tests/LLVMTests/IRExceptionSpec.swift
@@ -17,8 +17,7 @@ class IRExceptionSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // IRRESUME: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRRESUME-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -39,8 +38,7 @@ class IRExceptionSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // IRCLEANUP: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRCLEANUP-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -66,8 +64,7 @@ class IRExceptionSpec : XCTestCase {
 
       // IRCATCH: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRCATCH-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -95,8 +92,7 @@ class IRExceptionSpec : XCTestCase {
 
       // IRCATCHFILTER: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // IRCATCHFILTER-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)

--- a/Tests/LLVMTests/IRInstructionSpec.swift
+++ b/Tests/LLVMTests/IRInstructionSpec.swift
@@ -16,13 +16,13 @@ class IRInstructionSpec : XCTestCase {
     let global = module.addGlobal("type_info", type: structTy)
 
     let f = module.addFunction("test",
-                               type: FunctionType(argTypes: [
+                               type: FunctionType([
                                   IntType.int1,
                                   FloatType.float,
                                   PointerType.toVoid,
                                   structTy,
                                   VectorType(elementType: IntType.int32, count: 42),
-                                ], returnType: VoidType()))
+                               ], VoidType()))
     let entry = f.appendBasicBlock(named: "entry")
     let landing = f.appendBasicBlock(named: "landing")
     builder.positionAtEnd(of: landing)

--- a/Tests/LLVMTests/IRIntrinsicSpec.swift
+++ b/Tests/LLVMTests/IRIntrinsicSpec.swift
@@ -15,9 +15,9 @@ class IRIntrinsicSpec : XCTestCase {
 
       // IRINTRINSIC: define i32 @readOneArg(i32, ...) {
       let main = builder.addFunction("readOneArg",
-                                     type: FunctionType(argTypes: [IntType.int32],
-                                                        returnType: IntType.int32,
-                                                        isVarArg: true))
+                                     type: FunctionType([IntType.int32],
+                                                        IntType.int32,
+                                                        variadic: true))
       // IRINTRINSIC-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -69,8 +69,7 @@ class IRIntrinsicSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // VIRTUALOVERLOAD-IRINTRINSIC: define i32 @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int32))
+                                     type: FunctionType([], IntType.int32))
       // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -104,8 +103,7 @@ class IRIntrinsicSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       // INTRINSIC-FAMILY-RESOLVE: define i32 @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int32))
+                                     type: FunctionType([], IntType.int32))
       // INTRINSIC-FAMILY-RESOLVE-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)

--- a/Tests/LLVMTests/IROperationSpec.swift
+++ b/Tests/LLVMTests/IROperationSpec.swift
@@ -27,8 +27,7 @@ class IROperationSpec : XCTestCase {
 
       // BINARYOP: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // BINARYOP-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -105,8 +104,7 @@ class IROperationSpec : XCTestCase {
 
       // CASTOP: define void @main() {
       let main = builder.addFunction("main",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: VoidType()))
+                                     type: FunctionType([], VoidType()))
       // CASTOP-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)

--- a/Tests/LLVMTests/JITSpec.swift
+++ b/Tests/LLVMTests/JITSpec.swift
@@ -29,15 +29,13 @@ class JITSpec : XCTestCase {
 
     var llvmSwiftFn = builder.addFunction(
       "calculateSwiftFibs",
-      type: FunctionType(argTypes: [IntType.int1],
-                         returnType: FloatType.double)
+      type: FunctionType([IntType.int1], FloatType.double)
     )
     llvmSwiftFn.linkage = .external
 
     let function = builder.addFunction(
       "calculateFibs",
-      type: FunctionType(argTypes: [IntType.int1],
-                         returnType: FloatType.double)
+      type: FunctionType([IntType.int1], FloatType.double)
     )
     let entryBB = function.appendBasicBlock(named: "entry")
     builder.positionAtEnd(of: entryBB)
@@ -82,7 +80,7 @@ class JITSpec : XCTestCase {
     let ret = builder.buildLoad(local, name: "ret")
     builder.buildRet(ret)
 
-    let main = builder.addFunction("main", type: FunctionType(argTypes: [], returnType: VoidType()))
+    let main = builder.addFunction("main", type: FunctionType([], VoidType()))
     let mainEntry = main.appendBasicBlock(named: "entry")
     builder.positionAtEnd(of: mainEntry)
     _ = builder.buildCall(llvmSwiftFn, args: [ IntType.int1.constant(1) ])

--- a/Tests/LLVMTests/ModuleLinkSpec.swift
+++ b/Tests/LLVMTests/ModuleLinkSpec.swift
@@ -13,8 +13,7 @@ class ModuleLinkSpec : XCTestCase {
       let builder1 = IRBuilder(module: module1)
       // MODULE-LINK: define void @moduleOne() {
       let mod1f = builder1.addFunction("moduleOne",
-                                       type: FunctionType(argTypes: [],
-                                                          returnType: VoidType()))
+                                       type: FunctionType([], VoidType()))
       // MODULE-LINK-NEXT: entry:
       let entry1 = mod1f.appendBasicBlock(named: "entry")
       builder1.positionAtEnd(of: entry1)
@@ -30,8 +29,7 @@ class ModuleLinkSpec : XCTestCase {
       let builder2 = IRBuilder(module: module2)
       // MODULE-LINK: define void @moduleTwo() {
       let mod2f = builder2.addFunction("moduleTwo",
-                                       type: FunctionType(argTypes: [],
-                                                          returnType: VoidType()))
+                                       type: FunctionType([], VoidType()))
       // MODULE-LINK-NEXT: entry:
       let entry2 = mod2f.appendBasicBlock(named: "entry")
       builder2.positionAtEnd(of: entry2)

--- a/Tests/LLVMTests/iRMetadataSpec.swift
+++ b/Tests/LLVMTests/iRMetadataSpec.swift
@@ -37,8 +37,7 @@ class IRMetadataSpec : XCTestCase {
 
       // IRINSTRMETADATA: define i32 @test() {
       let main = builder.addFunction("test",
-                                     type: FunctionType(argTypes: [],
-                                                        returnType: IntType.int32))
+                                     type: FunctionType([], IntType.int32))
       // IRINSTRMETADATA-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -66,8 +65,9 @@ class IRMetadataSpec : XCTestCase {
 
       // IRFPMATHMETADATA: define float @test(float, float) {
       let main = builder.addFunction("test",
-                                     type: FunctionType(argTypes: [FloatType.float, FloatType.float],
-                                                        returnType: FloatType.float))
+                                     type: FunctionType([
+                                       FloatType.float, FloatType.float
+                                     ], FloatType.float))
       // IRFPMATHMETADATA-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -93,8 +93,10 @@ class IRMetadataSpec : XCTestCase {
 
       // IRBWMETADATA: define float @test(i1, float, float) {
       let main = builder.addFunction("test",
-                                     type: FunctionType(argTypes: [IntType.int1, FloatType.float, FloatType.float],
-                                                        returnType: FloatType.float))
+                                     type: FunctionType([
+                                       IntType.int1,
+                                       FloatType.float, FloatType.float
+                                     ], FloatType.float))
       // IRBWMETADATA-NEXT: entry:
       let entry = main.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: entry)
@@ -149,7 +151,7 @@ class IRMetadataSpec : XCTestCase {
       let MDB = MDBuilder()
 
       // IRSIMPLETBAA: define void @main() {
-      let F = module.addFunction("main", type: FunctionType(argTypes: [], returnType: VoidType()))
+      let F = module.addFunction("main", type: FunctionType([], VoidType()))
       // IRSIMPLETBAA-NEXT: entry:
       let bb = F.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: bb)
@@ -225,7 +227,7 @@ class IRMetadataSpec : XCTestCase {
       let MDB = MDBuilder()
 
       // IRMEMTRANSFERTBAA: define void @main(i8*) {
-      let F = module.addFunction("main", type: FunctionType(argTypes: [PointerType.toVoid], returnType: VoidType()))
+      let F = module.addFunction("main", type: FunctionType([PointerType.toVoid], VoidType()))
       // IRMEMTRANSFERTBAA-NEXT: entry:
       let bb = F.appendBasicBlock(named: "entry")
       builder.positionAtEnd(of: bb)


### PR DESCRIPTION
This API change is happening for a few reasons

- The existing initializer's labels are not fully spelled out
- The existing initializer's labels do not match the reality of the LLVM API ("args" instead of "parameters", "varargs" instead of "variadic")
- It is obvious from context what these parameters are.

Introduce a deprecation warning with this release.  We will be removing these APIs from the next major version of LLVMSwift.