### PR TITLE
Redo the Pass Manager

### DIFF
--- a/Sources/LLVM/PassManager.swift
+++ b/Sources/LLVM/PassManager.swift
@@ -44,6 +44,20 @@ public enum Pass {
   /// %Z = add int 2, %X
   /// ```
   case instructionCombining
+  /// Working in conjunction with the linker, iterate through all functions and
+  /// global values in the module and attempt to change their linkage from
+  /// external to internal.
+  ///
+  /// To preserve the linkage of a global value, return `true` from the given
+  /// callback.
+  case internalize(mustPreserve: (IRGlobal) -> Bool)
+  /// Working in conjunction with the linker, iterate through all functions and
+  /// global values in the module and attempt to change their linkage from
+  /// external to internal.
+  ///
+  /// When a function with the name "main" is encountered, if the value of
+  /// `preserveMain` is `true`, "main" will not be internalized.
+  case internalizeAll(preserveMain: Bool)
   /// Thread control through mult-pred/multi-succ blocks where some preds
   /// always go to some succ. Thresholds other than minus one override the
   /// internal BB duplication default threshold.
@@ -92,6 +106,10 @@ public enum Pass {
   /// ret i32 42
   /// ```
   case promoteMemoryToRegister
+  /// Adds DWARF discriminators to the IR.  Discriminators are
+  /// used to decide what CFG path was taken inside sub-graphs whose instructions
+  /// share the same line and column number information.
+  case addDiscriminators
   /// This pass reassociates commutative expressions in an order that
   /// is designed to promote better constant propagation, GCSE, LICM, PRE, etc.
   ///

--- a/Sources/LLVM/PassPipeliner.swift
+++ b/Sources/LLVM/PassPipeliner.swift
@@ -1,0 +1,284 @@
+#if SWIFT_PACKAGE
+import cllvm
+#endif
+
+/// Implements a pass manager, pipeliner, and executor for a set of
+/// user-provided optimization passes.
+///
+/// A `PassPipeliner` handles the creation of a related set of optimization
+/// passes called a "pipeline".  Grouping passes is done for multiple reasons,
+/// chief among them is that optimizer passes are extremely sensitive to their
+/// ordering relative to other passses.  In addition, pass groupings allow for
+/// the clean segregation of otherwise unrelated passes.  For example, a
+/// pipeline might consist of "mandatory" passes such as Jump Threading, LICM,
+/// and DCE in one pipeline and "diagnostic" passes in another.
+public final class PassPipeliner {
+  private enum Pipeline {
+    case builtinPasses([Pass])
+    case functionPassManager(LLVMPassManagerRef)
+    case modulePassManager(LLVMPassManagerRef)
+  }
+
+  /// The module for this pass pipeline.
+  public let module: Module
+  /// The pipeline stages registered with this pass pipeliner.
+  public private(set) var stages: [String]
+
+  private var stageMapping: [String: Pipeline]
+  private var frozen: Bool = false
+
+  public final class Builder {
+    fileprivate var passes: [Pass] = []
+
+    fileprivate init() {}
+
+    /// Appends a pass to the current pipeline.
+    public func add(_ type: Pass) {
+      self.passes.append(type)
+    }
+  }
+
+  /// Initializes a new, empty pipeliner.
+  ///
+  /// - Parameter module: The module the pipeliner will run over.
+  public init(module: Module) {
+    self.module = module
+    self.stages = []
+    self.stageMapping = [:]
+  }
+
+  deinit {
+    for stage in stageMapping.values {
+      switch stage {
+      case let .functionPassManager(pm):
+        LLVMDisposePassManager(pm)
+      case let .modulePassManager(pm):
+        LLVMDisposePassManager(pm)
+      case .builtinPasses(_):
+        continue
+      }
+    }
+  }
+
+  /// Appends a stage to the pipeliner.
+  ///
+  /// The staging function provides a `Builder` object into which the types
+  /// of passes for a given pipeline are inserted.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the pipeline stage.
+  ///   - stager: A builder function.
+  public func addStage(_ name: String, _ stager: (Builder) -> Void) {
+    precondition(!self.frozen, "Cannot add new stages to a frozen pipeline!")
+
+    self.frozen = true
+    defer { self.frozen = false }
+
+    self.stages.append(name)
+    let builder = Builder()
+    stager(builder)
+    self.stageMapping[name] = .builtinPasses(builder.passes)
+  }
+
+  /// Executes the entirety of the pass pipeline.
+  ///
+  /// Execution of passes is done in a loop that is divided into two phases.
+  /// The first phase aggregates all local passes and stops aggregation when
+  /// it encounters a module-level pass.  This group of local passes
+  /// is then run one at a time on the same scope.  The second phase is entered
+  /// and the module pass is run.  The first phase is then re-entered until all
+  /// local passes have run on all local scopes and all intervening module
+  /// passes have been run.
+  ///
+  /// The same pipeline may be repeatedly re-executed, but pipeline execution
+  /// is not re-entrancy safe.
+  public func execute() {
+    precondition(!self.frozen, "Cannot execute a frozen pipeline!")
+
+    self.frozen = true
+    defer { self.frozen = false }
+
+    stageLoop: for stage in self.stages {
+      guard let pipeline = self.stageMapping[stage] else {
+        fatalError("Unregistered pass stage?")
+      }
+
+      switch pipeline {
+      case let .builtinPasses(passTypes):
+        guard !passTypes.isEmpty else {
+          continue stageLoop
+        }
+        self.runPasses(passTypes)
+      case let .functionPassManager(pm):
+        self.runFunctionPasses([], pm)
+      case let .modulePassManager(pm):
+        LLVMRunPassManager(pm, self.module.llvm)
+      }
+    }
+  }
+
+  private func runFunctionPasses(_ passes: [Pass], _ pm: LLVMPassManagerRef) {
+    LLVMInitializeFunctionPassManager(pm)
+
+    for pass in passes {
+      PassPipeliner.passMapping[pass]!(pm)
+    }
+
+    for function in self.module.functions {
+      LLVMRunFunctionPassManager(pm, function.asLLVM())
+    }
+  }
+
+  private func runPasses(_ passes: [Pass]) {
+    let pm = LLVMCreatePassManager()!
+    for pass in passes {
+      PassPipeliner.passMapping[pass]!(pm)
+    }
+    LLVMRunPassManager(pm, self.module.llvm)
+    LLVMDisposePassManager(pm)
+  }
+}
+
+// MARK: Standard Pass Pipelines
+
+extension PassPipeliner {
+  public func addStandardFunctionPipeline(
+    _ name: String,
+    optimization: CodeGenOptLevel = .`default`,
+    size: CodeGenOptLevel = .none
+  ) {
+    let passBuilder = self.configurePassBuilder(optimization, size)
+    let functionPasses =
+      LLVMCreateFunctionPassManagerForModule(self.module.llvm)!
+    LLVMPassManagerBuilderPopulateFunctionPassManager(passBuilder,
+                                                      functionPasses)
+    LLVMPassManagerBuilderDispose(passBuilder)
+    self.stages.append(name)
+    self.stageMapping[name] = .functionPassManager(functionPasses)
+  }
+
+  public func addStandardModulePipeline(
+    _ name: String,
+    optimization: CodeGenOptLevel = .`default`,
+    size: CodeGenOptLevel = .none
+  ) {
+    let passBuilder = self.configurePassBuilder(optimization, size)
+    let modulePasses = LLVMCreatePassManager()!
+    LLVMPassManagerBuilderPopulateModulePassManager(passBuilder, modulePasses)
+    LLVMPassManagerBuilderDispose(passBuilder)
+    self.stages.append(name)
+    self.stageMapping[name] = .modulePassManager(modulePasses)
+  }
+
+  private func configurePassBuilder(
+    _ opt: CodeGenOptLevel,
+    _ size: CodeGenOptLevel
+  ) -> LLVMPassManagerBuilderRef {
+    let passBuilder = LLVMPassManagerBuilderCreate()!
+    switch opt {
+    case .none:
+      LLVMPassManagerBuilderSetOptLevel(passBuilder, 0)
+    case .less:
+      LLVMPassManagerBuilderSetOptLevel(passBuilder, 1)
+    case .default:
+      LLVMPassManagerBuilderSetOptLevel(passBuilder, 2)
+    case .aggressive:
+      LLVMPassManagerBuilderSetOptLevel(passBuilder, 3)
+    }
+
+    switch size {
+    case .none:
+      LLVMPassManagerBuilderSetSizeLevel(passBuilder, 0)
+    case .less:
+      LLVMPassManagerBuilderSetSizeLevel(passBuilder, 1)
+    case .default:
+      LLVMPassManagerBuilderSetSizeLevel(passBuilder, 2)
+    case .aggressive:
+      LLVMPassManagerBuilderSetSizeLevel(passBuilder, 3)
+    }
+
+    return passBuilder
+  }
+}
+
+
+extension PassPipeliner {
+  static let passMapping: [Pass: (LLVMPassManagerRef) -> Void] = [
+    .aggressiveDCE: LLVMAddAggressiveDCEPass,
+    .bitTrackingDCE: LLVMAddBitTrackingDCEPass,
+    .alignmentFromAssumptions: LLVMAddAlignmentFromAssumptionsPass,
+    .cfgSimplification: LLVMAddCFGSimplificationPass,
+    .deadStoreElimination: LLVMAddDeadStoreEliminationPass,
+    .scalarizer: LLVMAddScalarizerPass,
+    .mergedLoadStoreMotion: LLVMAddMergedLoadStoreMotionPass,
+    .gvn: LLVMAddGVNPass,
+    .indVarSimplify: LLVMAddIndVarSimplifyPass,
+    .instructionCombining: LLVMAddInstructionCombiningPass,
+    .jumpThreading: LLVMAddJumpThreadingPass,
+    .licm: LLVMAddLICMPass,
+    .loopDeletion: LLVMAddLoopDeletionPass,
+    .loopIdiom: LLVMAddLoopIdiomPass,
+    .loopRotate: LLVMAddLoopRotatePass,
+    .loopReroll: LLVMAddLoopRerollPass,
+    .loopUnroll: LLVMAddLoopUnrollPass,
+    .loopUnrollAndJam: LLVMAddLoopUnrollAndJamPass,
+    .loopUnswitch: LLVMAddLoopUnswitchPass,
+    .lowerAtomic: LLVMAddLowerAtomicPass,
+    .memCpyOpt: LLVMAddMemCpyOptPass,
+    .partiallyInlineLibCalls: LLVMAddPartiallyInlineLibCallsPass,
+    .lowerSwitch: LLVMAddLowerSwitchPass,
+    .promoteMemoryToRegister: LLVMAddPromoteMemoryToRegisterPass,
+    .reassociate: LLVMAddReassociatePass,
+    .sccp: LLVMAddSCCPPass,
+    .scalarReplAggregates: LLVMAddScalarReplAggregatesPass,
+    .scalarReplAggregatesSSA: LLVMAddScalarReplAggregatesPassSSA,
+    .tailCallElimination: LLVMAddTailCallEliminationPass,
+    .constantPropagation: LLVMAddConstantPropagationPass,
+    .demoteMemoryToRegister: LLVMAddDemoteMemoryToRegisterPass,
+    .verifier: LLVMAddVerifierPass,
+    .correlatedValuePropagation: LLVMAddCorrelatedValuePropagationPass,
+    .earlyCSE: LLVMAddEarlyCSEPass,
+    .lowerExpectIntrinsic: LLVMAddLowerExpectIntrinsicPass,
+    .typeBasedAliasAnalysis: LLVMAddTypeBasedAliasAnalysisPass,
+    .scopedNoAliasAA: LLVMAddScopedNoAliasAAPass,
+    .basicAliasAnalysis: LLVMAddBasicAliasAnalysisPass,
+    .unifyFunctionExitNodes: LLVMAddUnifyFunctionExitNodesPass,
+    .alwaysInliner: LLVMAddAlwaysInlinerPass,
+    .argumentPromotion: LLVMAddArgumentPromotionPass,
+    .constantMerge: LLVMAddConstantMergePass,
+    .deadArgElimination: LLVMAddDeadArgEliminationPass,
+    .functionAttrs: LLVMAddFunctionAttrsPass,
+    .functionInlining: LLVMAddFunctionInliningPass,
+    .globalDCE: LLVMAddGlobalDCEPass,
+    .globalOptimizer: LLVMAddGlobalOptimizerPass,
+    .ipConstantPropagation: LLVMAddIPConstantPropagationPass,
+    .ipscc: LLVMAddIPSCCPPass,
+    .pruneEH: LLVMAddPruneEHPass,
+    .stripDeadPrototypes: LLVMAddStripDeadPrototypesPass,
+    .stripSymbols: LLVMAddStripSymbolsPass,
+    .loopVectorize: LLVMAddLoopVectorizePass,
+    .slpVectorize: LLVMAddSLPVectorizePass,
+    //    .internalize: LLVMAddInternalizePass,
+    //    .sroaWithThreshhold: LLVMAddScalarReplAggregatesPassWithThreshold,
+  ]
+}
+
+extension Pass {
+  var isModulePass: Bool {
+    switch self {
+    case .stripSymbols,
+         .stripDeadPrototypes,
+         .constantMerge,
+         .globalOptimizer,
+         .globalDCE,
+         .deadArgElimination,
+         .ipConstantPropagation,
+         .ipscc,
+         .functionAttrs,
+         .functionInlining:
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/llvmshims/include/shim.h
+++ b/Sources/llvmshims/include/shim.h
@@ -96,4 +96,10 @@ uint64_t LLVMGlobalGetGUID(LLVMValueRef Global);
 void LLVMAppendExistingBasicBlock(LLVMValueRef Fn,
                                   LLVMBasicBlockRef BB);
 
+void LLVMAddAddDiscriminatorsPass(LLVMPassManagerRef PM);
+
+void LLVMAddInternalizePassWithMustPreservePredicate(
+  LLVMPassManagerRef PM, void *Context,
+  LLVMBool (*MustPreserve)(LLVMValueRef, void *));
+
 #endif /* LLVMSWIFT_LLVM_SHIM_H */

--- a/Tests/LLVMTests/IRPassManagerSpec.swift
+++ b/Tests/LLVMTests/IRPassManagerSpec.swift
@@ -1,0 +1,215 @@
+import LLVM
+import XCTest
+import FileCheck
+import Foundation
+
+class IRPassManagerSpec : XCTestCase {
+  func testEmptyPassPipeliner() {
+    let module = Module(name: "Test")
+    let pipeliner = PassPipeliner(module: module)
+    XCTAssertTrue(pipeliner.stages.isEmpty)
+  }
+
+  func testAppendStages() {
+    let module = Module(name: "Test")
+    let pipeliner = PassPipeliner(module: module)
+    XCTAssertTrue(pipeliner.stages.isEmpty)
+    var rng = SystemRandomNumberGenerator()
+    let stageCount = (rng.next() % 25)
+    for i in 0..<stageCount {
+      pipeliner.addStage("stage \(i)") { p in }
+    }
+
+    XCTAssertEqual(pipeliner.stages.count, Int(stageCount))
+  }
+
+  func testAppendStandardStages() {
+    let module = Module(name: "Test")
+    let pipeliner = PassPipeliner(module: module)
+    XCTAssertTrue(pipeliner.stages.isEmpty)
+    for i in 0...3 {
+      let optLevel: CodeGenOptLevel
+      switch i {
+      case 0:
+        optLevel = .none
+      case 1:
+        optLevel = .less
+      case 2:
+        optLevel = .`default`
+      case 3:
+        optLevel = .aggressive
+      default:
+        fatalError()
+      }
+      for j in 0...3 {
+        let sizeLevel: CodeGenOptLevel
+        switch i {
+        case 0:
+          sizeLevel = .none
+        case 1:
+          sizeLevel = .less
+        case 2:
+          sizeLevel = .`default`
+        case 3:
+          sizeLevel = .aggressive
+        default:
+          fatalError()
+        }
+        pipeliner.addStandardModulePipeline("Opt \(i) Size \(j)", optimization: optLevel, size: sizeLevel)
+      }
+    }
+
+    XCTAssertEqual(pipeliner.stages.count, 4 * 4)
+
+    for i in 0...3 {
+      let optLevel: CodeGenOptLevel
+      switch i {
+      case 0:
+        optLevel = .none
+      case 1:
+        optLevel = .less
+      case 2:
+        optLevel = .`default`
+      case 3:
+        optLevel = .aggressive
+      default:
+        fatalError()
+      }
+      for j in 0...3 {
+        let sizeLevel: CodeGenOptLevel
+        switch i {
+        case 0:
+          sizeLevel = .none
+        case 1:
+          sizeLevel = .less
+        case 2:
+          sizeLevel = .`default`
+        case 3:
+          sizeLevel = .aggressive
+        default:
+          fatalError()
+        }
+        pipeliner.addStandardFunctionPipeline("Opt \(i) Size \(j)", optimization: optLevel, size: sizeLevel)
+      }
+    }
+
+    XCTAssertEqual(pipeliner.stages.count, (4 * 4) + (4 * 4))
+  }
+
+  func testExecute() {
+    let module = self.createModule()
+    let pipeliner = PassPipeliner(module: module)
+
+    pipeliner.addStandardFunctionPipeline("Standard", optimization: .aggressive)
+    pipeliner.addStandardModulePipeline("Module", optimization: .aggressive)
+
+    XCTAssertTrue(fileCheckOutput(of: .stderr, withPrefixes: [ "CHECK-EXECUTE-STDOPT" ]) {
+      module.dump()
+
+      // CHECK-EXECUTE-STDOPT:  ; ModuleID = 'Test'
+      // CHECK-EXECUTE-STDOPT:  source_filename = "Test"
+
+      // CHECK-EXECUTE-STDOPT:  define i32 @fun(i32, i32) {
+      // CHECK-EXECUTE-STDOPT:    entry:
+      // CHECK-EXECUTE-STDOPT:    %2 = alloca i32, align 4
+      // CHECK-EXECUTE-STDOPT:    %3 = alloca i32, align 4
+      // CHECK-EXECUTE-STDOPT:    %4 = alloca i32, align 4
+      // CHECK-EXECUTE-STDOPT:    store i32 %0, i32* %2
+      // CHECK-EXECUTE-STDOPT:    store i32 %1, i32* %3
+      // CHECK-EXECUTE-STDOPT:    store i32 4, i32* %4
+      // CHECK-EXECUTE-STDOPT:    %5 = load i32, i32* %2, align 4
+      // CHECK-EXECUTE-STDOPT:    %6 = icmp eq i32 %5, 1
+      // CHECK-EXECUTE-STDOPT:    br i1 %6, label %block1, label %block2
+
+      // CHECK-EXECUTE-STDOPT:    block1:
+      // CHECK-EXECUTE-STDOPT:    %7 = load i32, i32* %2, align 4
+      // CHECK-EXECUTE-STDOPT:    %8 = load i32, i32* %4, align 4
+      // CHECK-EXECUTE-STDOPT:    %9 = add nsw i32 %7, %8
+      // CHECK-EXECUTE-STDOPT:    store i32 %9, i32* %4
+      // CHECK-EXECUTE-STDOPT:    br label %merge
+
+      // CHECK-EXECUTE-STDOPT:    block2:
+      // CHECK-EXECUTE-STDOPT:    %10 = load i32, i32* %3, align 4
+      // CHECK-EXECUTE-STDOPT:    %11 = load i32, i32* %4, align 4
+      // CHECK-EXECUTE-STDOPT:    %12 = add nsw i32 %10, %11
+      // CHECK-EXECUTE-STDOPT:    store i32 %12, i32* %4
+      // CHECK-EXECUTE-STDOPT:    br label %merge
+
+      // CHECK-EXECUTE-STDOPT:    merge:
+      // CHECK-EXECUTE-STDOPT:    %13 = load i32, i32* %4, align 4
+      // CHECK-EXECUTE-STDOPT:    ret i32 %13
+      // CHECK-EXECUTE-STDOPT  }
+
+      pipeliner.execute()
+
+      module.dump()
+
+      // CHECK-EXECUTE-STDOPT: ; ModuleID = 'Test'
+      // CHECK-EXECUTE-STDOPT: source_filename = "Test"
+
+      // CHECK-EXECUTE-STDOPT: ; Function Attrs: norecurse nounwind readnone
+      // CHECK-EXECUTE-STDOPT: define i32 @fun(i32, i32) local_unnamed_addr #0 {
+      // CHECK-EXECUTE-STDOPT:   entry:
+      // CHECK-EXECUTE-STDOPT:   %2 = icmp eq i32 %0, 1
+      // CHECK-EXECUTE-STDOPT:   %3 = add nsw i32 %1, 4
+      // CHECK-EXECUTE-STDOPT:   %.0 = select i1 %2, i32 5, i32 %3
+      // CHECK-EXECUTE-STDOPT:   ret i32 %.0
+      // CHECK-EXECUTE-STDOPT: }
+    })
+  }
+
+  private func createModule() -> Module {
+    let module = Module(name: "Test")
+
+    let builder = IRBuilder(module: module)
+    let fun = builder.addFunction("fun",
+                                  type: FunctionType([
+                                    IntType.int32,
+                                    IntType.int32,
+                                  ], IntType.int32))
+    let entry = fun.appendBasicBlock(named: "entry")
+    let block1 = fun.appendBasicBlock(named: "block1")
+    let block2 = fun.appendBasicBlock(named: "block2")
+    let merge = fun.appendBasicBlock(named: "merge")
+
+    builder.positionAtEnd(of: entry)
+    let val1 = builder.buildAlloca(type: IntType.int32, alignment: Alignment(4))
+    let val2 = builder.buildAlloca(type: IntType.int32, alignment: Alignment(4))
+    let val3 = builder.buildAlloca(type: IntType.int32, alignment: Alignment(4))
+    builder.buildStore(fun.parameters[0], to: val1)
+    builder.buildStore(fun.parameters[1], to: val2)
+    builder.buildStore(IntType.int32.constant(4), to: val3)
+    let reloadVal1 = builder.buildLoad(val1, alignment: Alignment(4))
+    let cmpVal = builder.buildICmp(reloadVal1, IntType.int32.constant(1), .equal)
+    builder.buildCondBr(condition: cmpVal, then: block1, else: block2)
+
+    builder.positionAtEnd(of: block1)
+    let reloadVal2 = builder.buildLoad(val1, alignment: Alignment(4))
+    let reloadVal3 = builder.buildLoad(val3, alignment: Alignment(4))
+    let sum1 = builder.buildAdd(reloadVal2, reloadVal3, overflowBehavior: .noSignedWrap)
+    builder.buildStore(sum1, to: val3)
+    builder.buildBr(merge)
+
+    builder.positionAtEnd(of: block2)
+    let reloadVal4 = builder.buildLoad(val2, alignment: Alignment(4))
+    let reloadVal5 = builder.buildLoad(val3, alignment: Alignment(4))
+    let sum2 = builder.buildAdd(reloadVal4, reloadVal5, overflowBehavior: .noSignedWrap)
+    builder.buildStore(sum2, to: val3)
+    builder.buildBr(merge)
+
+    builder.positionAtEnd(of: merge)
+    let reloadVal6 = builder.buildLoad(val3, alignment: Alignment(4))
+    builder.buildRet(reloadVal6)
+
+    return module
+  }
+
+  #if !os(macOS)
+  static var allTests = testCase([
+    ("testEmptyPassPipeliner", testEmptyPassPipeliner),
+    ("testAppendStages", testAppendStages),
+    ("testAppendStandardStages", testAppendStandardStages),
+    ("testExecute", testExecute),
+  ])
+  #endif
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,6 +17,7 @@ XCTMain([
   IRInstructionSpec.allTests,
   IRMetadataSpec.allTests,
   IROperationSpec.allTests,
+  IRPassManagerSpec.allTests,
   JITSpec.allTests,
   ModuleLinkSpec.allTests,
   ModuleMetadataSpec.allTests,


### PR DESCRIPTION
This thing was never correct.  We mixed up Function passes and Module passes, and if you were unlucky enough to schedule both into the function pass manager then LLVM would probably crash.

Provide the interface we were shooting for here anyways in the form of a Swift-like pass pipeliner.  You can freely mix module and function-level passes in the pipeliner, and we will schedule them the way LLVM would anyways (group the function passes, then run the module passes).  There's bindings for LTO passes that never made it into a header that we could also wrap with this infrastructure.