### PR TITLE
Deploy to macOS 10.14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
   name: "LLVM",
+  platforms: [
+    .macOS(.v10_14),
+  ],
   products: [
     .library(
       name: "LLVM",


### PR DESCRIPTION
Begin requiring macOS 10.14.  Deployment to earlier OSes was never
guaranteed to work, and this was causing thousands of linker warnings in
otherwise valid targets.