### PR TITLE
Migrate GEPs to use opaque pointer compatable APIs

### DIFF
--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1153,6 +1153,22 @@ extension IRBuilder {
     return LLVMBuildStructGEP(llvm, ptr.asLLVM(), UInt32(index), name)
   }
 
+  /// Build a GEP (Get Element Pointer) instruction suitable for indexing into
+  /// a struct. This uses LLVMBuildStructGEP2 from cllvm
+  ///
+  /// - parameter ptr: The base address for the index calculation.
+  /// - parameter type: The type of the struct to index into. If nil is specified, the
+  ///   type property of the pointer is used.
+  /// - parameter index: The offset from the base for the index calculation.
+  /// - parameter name: The name for the newly inserted instruction.
+  ///
+  /// - returns: A value representing the address of a subelement of the given
+  ///   struct value.
+  public func buildStructGEP2(_ ptr: IRValue, type: IRType? = nil, index: Int, name: String = "") -> IRValue {
+    let structType = type ?? ptr.type
+    return LLVMBuildStructGEP2(llvm, structType.asLLVM(), ptr.asLLVM(), UInt32(index), name)
+  }
+  
   /// Build an ExtractValue instruction to retrieve an indexed value from a
   /// struct or array value.
   ///

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1090,6 +1090,7 @@ extension IRBuilder {
   ///
   /// - returns: A value representing the result of a load from the given
   ///   pointer value.
+  @available(*, deprecated, message: "Use buildLoad(type:ptr:ordering:volatile:alignment:name) instead")
   public func buildLoad(_ ptr: IRValue, ordering: AtomicOrdering = .notAtomic, volatile: Bool = false, alignment: Alignment = .zero, name: String = "") -> IRInstruction {
     let loadInst = LLVMBuildLoad(llvm, ptr.asLLVM(), name)!
     LLVMSetOrdering(loadInst, ordering.llvm)
@@ -1097,7 +1098,28 @@ extension IRBuilder {
     LLVMSetAlignment(loadInst, alignment.rawValue)
     return loadInst
   }
-
+  
+  /// Build a load instruction that loads a value from the location in the
+  /// given value.
+  ///
+  /// - parameter ptr: The pointer value to load from.
+  /// - parameter type: The type of value loaded from the given pointer.
+  /// - parameter ordering: The ordering effect of the fence for this load,
+  ///   if any.  Defaults to a nonatomic load.
+  /// - parameter volatile: Whether this is a load from a volatile memory location.
+  /// - parameter alignment: The alignment of the access.
+  /// - parameter name: The name for the newly inserted instruction.
+  ///
+  /// - returns: A value representing the result of a load from the given
+  ///   pointer value.
+  public func buildLoad(_ ptr: IRValue, type: IRType, ordering: AtomicOrdering = .notAtomic, volatile: Bool = false, alignment: Alignment = .zero, name: String = "") -> IRInstruction {
+    let loadInst = LLVMBuildLoad2(llvm, type.asLLVM(), ptr.asLLVM(), name)!
+    LLVMSetOrdering(loadInst, ordering.llvm)
+    LLVMSetVolatile(loadInst, volatile.llvm)
+    LLVMSetAlignment(loadInst, alignment.rawValue)
+    return loadInst
+  }
+  
   /// Build a `GEP` (Get Element Pointer) instruction with a resultant value
   /// that is undefined if the address is outside the actual underlying
   /// allocated object and not the address one-past-the-end.
@@ -1113,10 +1135,34 @@ extension IRBuilder {
   ///
   /// - returns: A value representing the address of a subelement of the given
   ///   aggregate data structure value.
+  @available(*, deprecated, message: "Use buildInBoundsGEP(type:ptr:indices:name) instead")
   public func buildInBoundsGEP(_ ptr: IRValue, indices: [IRValue], name: String = "") -> IRValue {
     var vals = indices.map { $0.asLLVM() as Optional }
     return vals.withUnsafeMutableBufferPointer { buf in
       return LLVMBuildInBoundsGEP(llvm, ptr.asLLVM(), buf.baseAddress, UInt32(buf.count), name)
+    }
+  }
+  
+  /// Build a `GEP` (Get Element Pointer) instruction with a resultant value
+  /// that is undefined if the address is outside the actual underlying
+  /// allocated object and not the address one-past-the-end.
+  ///
+  /// The `GEP` instruction is often the source of confusion.  LLVM [provides a
+  /// document](http://llvm.org/docs/GetElementPtr.html) to answer questions
+  /// around its semantics and correct usage.
+  ///
+  /// - parameter ptr: The base address for the index calculation.
+  /// - parameter type: The type used to calculate pointer offsets.
+  /// - parameter indices: A list of indices that indicate which of the elements
+  ///   of the aggregate object are indexed.
+  /// - parameter name: The name for the newly inserted instruction.
+  ///
+  /// - returns: A value representing the address of a subelement of the given
+  ///   aggregate data structure value.
+  public func buildInBoundsGEP(_ ptr: IRValue, type: IRType, indices: [IRValue], name: String = "") -> IRValue {
+    var vals = indices.map { $0.asLLVM() as Optional }
+    return vals.withUnsafeMutableBufferPointer { buf in
+      return LLVMBuildInBoundsGEP2(llvm, type.asLLVM(), ptr.asLLVM(), buf.baseAddress, UInt32(buf.count), name)
     }
   }
 
@@ -1133,6 +1179,7 @@ extension IRBuilder {
   ///
   /// - returns: A value representing the address of a subelement of the given
   ///   aggregate data structure value.
+  @available(*, deprecated, message: "Use buildGEP(type:ptr:indices:name) instead")
   public func buildGEP(_ ptr: IRValue, indices: [IRValue], name: String = "") -> IRValue {
     var vals = indices.map { $0.asLLVM() as Optional }
     return vals.withUnsafeMutableBufferPointer { buf in
@@ -1140,6 +1187,27 @@ extension IRBuilder {
     }
   }
 
+  /// Build a GEP (Get Element Pointer) instruction.
+  ///
+  /// The `GEP` instruction is often the source of confusion.  LLVM [provides a
+  /// document](http://llvm.org/docs/GetElementPtr.html) to answer questions
+  /// around its semantics and correct usage.
+  ///
+  /// - parameter ptr: The base address for the index calculation.
+  /// - parameter type: The type used to calculate pointer offsets.
+  /// - parameter indices: A list of indices that indicate which of the elements
+  ///   of the aggregate object are indexed.
+  /// - parameter name: The name for the newly inserted instruction.
+  ///
+  /// - returns: A value representing the address of a subelement of the given
+  ///   aggregate data structure value.
+  public func buildGEP(_ ptr: IRValue, type: IRType, indices: [IRValue], name: String = "") -> IRValue {
+    var vals = indices.map { $0.asLLVM() as Optional }
+    return vals.withUnsafeMutableBufferPointer { buf in
+      return LLVMBuildGEP2(llvm, type.asLLVM(), ptr.asLLVM(), buf.baseAddress, UInt32(buf.count), name)
+    }
+  }
+  
   /// Build a GEP (Get Element Pointer) instruction suitable for indexing into
   /// a struct.
   ///
@@ -1149,24 +1217,23 @@ extension IRBuilder {
   ///
   /// - returns: A value representing the address of a subelement of the given
   ///   struct value.
+  @available(*, deprecated, message: "Use buildStructGEP(type:ptr:index:name) instead")
   public func buildStructGEP(_ ptr: IRValue, index: Int, name: String = "") -> IRValue {
     return LLVMBuildStructGEP(llvm, ptr.asLLVM(), UInt32(index), name)
   }
 
   /// Build a GEP (Get Element Pointer) instruction suitable for indexing into
-  /// a struct. This uses LLVMBuildStructGEP2 from cllvm
+  /// a struct of a given type.
   ///
   /// - parameter ptr: The base address for the index calculation.
-  /// - parameter type: The type of the struct to index into. If nil is specified, the
-  ///   type property of the pointer is used.
+  /// - parameter type: The type of the struct to index into.
   /// - parameter index: The offset from the base for the index calculation.
   /// - parameter name: The name for the newly inserted instruction.
   ///
   /// - returns: A value representing the address of a subelement of the given
   ///   struct value.
-  public func buildStructGEP2(_ ptr: IRValue, type: IRType? = nil, index: Int, name: String = "") -> IRValue {
-    let structType = type ?? ptr.type
-    return LLVMBuildStructGEP2(llvm, structType.asLLVM(), ptr.asLLVM(), UInt32(index), name)
+  public func buildStructGEP(_ ptr: IRValue, type: IRType, index: Int, name: String = "") -> IRValue {
+    return LLVMBuildStructGEP2(llvm, type.asLLVM(), ptr.asLLVM(), UInt32(index), name)
   }
   
   /// Build an ExtractValue instruction to retrieve an indexed value from a


### PR DESCRIPTION
Version 2 takes an explicit type parameter. This avoids a segmentation fault that happens when the pointer does not have an explicit type in LLVM