### PR TITLE
Move to swift-tools-version:5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 
 import PackageDescription
 


### PR DESCRIPTION
This allows SPM 5.2+'s package resolution to skip resolving dependencies that are only used by test targets—in this case, FileCheck and all the dependencies that it brings.