### PR TITLE
Remove LLVMAddInternalizePassWithMustPreservePredicate from shims

### DIFF
--- a/Sources/llvmshims/include/shim.h
+++ b/Sources/llvmshims/include/shim.h
@@ -23,10 +23,6 @@ uint64_t LLVMGlobalGetGUID(LLVMValueRef Global);
 
 void LLVMAddGlobalsAAWrapperPass(LLVMPassManagerRef PM);
 
-void LLVMAddInternalizePassWithMustPreservePredicate(
-  LLVMPassManagerRef PM, void *Context,
-  LLVMBool (*MustPreserve)(LLVMValueRef, void *));
-
 typedef enum {
   LLVMTailCallKindNone,
   LLVMTailCallKindTail,

--- a/Sources/llvmshims/src/shim.cpp
+++ b/Sources/llvmshims/src/shim.cpp
@@ -41,11 +41,6 @@ extern "C" {
   // https://reviews.llvm.org/D66237
   void LLVMAddGlobalsAAWrapperPass(LLVMPassManagerRef PM);
 
-  // https://reviews.llvm.org/D62456
-  void LLVMAddInternalizePassWithMustPreservePredicate(
-   LLVMPassManagerRef PM, void *Context,
-   LLVMBool (*MustPreserve)(LLVMValueRef, void *));
-
   // https://reviews.llvm.org/D66061
   typedef enum {
     LLVMTailCallKindNone,
@@ -83,14 +78,6 @@ const char *LLVMGetARMCanonicalArchName(const char *Name, size_t NameLen) {
 
 uint64_t LLVMGlobalGetGUID(LLVMValueRef Glob) {
   return unwrap<GlobalValue>(Glob)->getGUID();
-}
-
-void LLVMAddInternalizePassWithMustPreservePredicate(
-  LLVMPassManagerRef PM, void *Context,
-  LLVMBool (*Pred)(LLVMValueRef, void *)) {
-  unwrap(PM)->add(createInternalizePass([=](const GlobalValue &GV) {
-    return Pred(wrap(&GV), Context) == 0 ? false : true;
-  }));
 }
 
 void LLVMAddGlobalsAAWrapperPass(LLVMPassManagerRef PM) {


### PR DESCRIPTION
Resolves #222.

This symbol is already provided by `llvm-c` in `IPO.h` per [this addition](https://reviews.llvm.org/D62456). @CodaFi got this merged into upstream LLVM two years ago with the exact same implementation (see [here](https://github.com/llvm/llvm-project/blame/62ec4ac90738a5f2d209ed28c822223e58aaaeb7/llvm/include/llvm-c/Transforms/IPO.h) and [here](https://github.com/llvm/llvm-project/blame/62ec4ac90738a5f2d209ed28c822223e58aaaeb7/llvm/lib/Transforms/IPO/IPO.cpp) and compare with removed definition), so it is unclear to me why this just now broke.