### PR TITLE
Fix Unit tests under LLVM 11

### DIFF
--- a/Sources/LLVM/DIBuilder.swift
+++ b/Sources/LLVM/DIBuilder.swift
@@ -394,7 +394,7 @@ extension DIBuilder {
     named name: String,
     scope: DIScope, file: FileMetadata, line: Int,
     type: DIType, alwaysPreserve: Bool = false,
-    flags: DIFlags = [], alignment: Alignment = .zero
+    flags: DIFlags = [], alignment: Alignment
   ) -> LocalVariableMetadata {
     let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let variable = LLVMDIBuilderCreateAutoVariable(
@@ -502,7 +502,7 @@ extension DIBuilder {
   ///   - file: File where this member is defined.
   ///   - line: Line number.
   ///   - size: Member size.
-  ///   - alignmemnt: Member alignment.
+  ///   - alignment: Member alignment.
   ///   - elements: Enumeration elements.
   ///   - numElements: Number of enumeration elements.
   ///   - underlyingType: Underlying type of a C++11/ObjC fixed enum.
@@ -675,7 +675,7 @@ extension DIBuilder {
   ///   - addressSpace: The address space the pointer type reside in.
   ///   - name: The name of the pointer type.
   public func buildPointerType(
-    pointee: DIType, size: Size, alignment: Alignment = .zero,
+    pointee: DIType, size: Size, alignment: Alignment,
     addressSpace: AddressSpace = .zero, name: String = ""
   ) -> DIType {
     let radix = UInt32(self.module.dataLayout.intPointerType().width)
@@ -1258,15 +1258,14 @@ extension DIBuilder {
   ///   - expression: The location of the global relative to the attached
   ///     GlobalVariable.
   ///   - declaration: Reference to the corresponding declaration.
-  ///   - alignment: Variable alignment(or 0 if no alignment attr was
-  ///     specified)
+  ///   - alignment: Variable alignment
   public func buildGlobalExpression(
     named name: String, linkageName: String, type: DIType,
     scope: DIScope, file: FileMetadata, line: Int,
     isLocal: Bool = true,
     expression: ExpressionMetadata? = nil,
     declaration: IRMetadata? = nil,
-    alignment: Alignment = .zero
+    alignment: Alignment
   ) -> ExpressionMetadata {
     let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateGlobalVariableExpression(

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1034,9 +1034,8 @@ extension IRBuilder {
   /// allocated, otherwise `count` is defaulted to be one. If a constant
   /// alignment is specified, the value result of the allocation is guaranteed
   /// to be aligned to at least that boundary. The alignment may not be
-  /// greater than `1 << 29`. If not specified, or if zero, the target can
-  /// choose to align the allocation on any convenient boundary compatible with
-  /// the type.
+  /// greater than `1 << 29`. If not specified, or if zero, the target will
+  /// choose a default value that is convenient and compatible with the type.
   ///
   /// The returned value is allocated in the address space specified in the data layout string for the target. If
   /// no such value is specified, the value is allocated in the default address space.
@@ -1066,6 +1065,9 @@ extension IRBuilder {
   /// Build a store instruction that stores the first value into the location
   /// given in the second value.
   ///
+  /// If alignment is not specified, or if zero, the target will choose a default
+  /// value that is convenient and compatible with the type.
+  ///
   /// - parameter val: The source value.
   /// - parameter ptr: The destination pointer to store into.
   /// - parameter ordering: The ordering effect of the fence for this store,
@@ -1087,6 +1089,9 @@ extension IRBuilder {
 
   /// Build a load instruction that loads a value from the location in the
   /// given value.
+  ///
+  /// If alignment is not specified, or if zero, the target will choose a default
+  /// value that is convenient and compatible with the type.
   ///
   /// - parameter ptr: The pointer value to load from.
   /// - parameter type: The type of value loaded from the given pointer.
@@ -1932,6 +1937,9 @@ extension IRBuilder {
 extension IRBuilder {
   /// Build a load instruction that loads a value from the location in the
   /// given value.
+  ///
+  /// If alignment is not specified, or if zero, the target will choose a default
+  /// value that is convenient and compatible with the type.
   ///
   /// - parameter ptr: The pointer value to load from.
   /// - parameter ordering: The ordering effect of the fence for this load,

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1057,7 +1057,9 @@ extension IRBuilder {
     } else {
       allocaInst = LLVMBuildAlloca(llvm, type.asLLVM(), name)!
     }
-    LLVMSetAlignment(allocaInst, alignment.rawValue)
+    if !alignment.isZero {
+      LLVMSetAlignment(allocaInst, alignment.rawValue)
+    }
     return allocaInst
   }
 
@@ -1077,7 +1079,9 @@ extension IRBuilder {
     let storeInst = LLVMBuildStore(llvm, val.asLLVM(), ptr.asLLVM())!
     LLVMSetOrdering(storeInst, ordering.llvm)
     LLVMSetVolatile(storeInst, volatile.llvm)
-    LLVMSetAlignment(storeInst, alignment.rawValue)
+    if !alignment.isZero {
+      LLVMSetAlignment(storeInst, alignment.rawValue)
+    }
     return storeInst
   }
 
@@ -1098,7 +1102,9 @@ extension IRBuilder {
     let loadInst = LLVMBuildLoad2(llvm, type.asLLVM(), ptr.asLLVM(), name)!
     LLVMSetOrdering(loadInst, ordering.llvm)
     LLVMSetVolatile(loadInst, volatile.llvm)
-    LLVMSetAlignment(loadInst, alignment.rawValue)
+    if !alignment.isZero {
+      LLVMSetAlignment(loadInst, alignment.rawValue)
+    }
     return loadInst
   }
 
@@ -1941,7 +1947,9 @@ extension IRBuilder {
     let loadInst = LLVMBuildLoad(llvm, ptr.asLLVM(), name)!
     LLVMSetOrdering(loadInst, ordering.llvm)
     LLVMSetVolatile(loadInst, volatile.llvm)
-    LLVMSetAlignment(loadInst, alignment.rawValue)
+    if !alignment.isZero {
+      LLVMSetAlignment(loadInst, alignment.rawValue)
+    }
     return loadInst
   }
 

--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -11,6 +11,19 @@ import cllvm
 /// together with the LLVM linker, which merges function (and global variable)
 /// definitions, resolves forward declarations, and merges symbol table entries.
 ///
+/// Creating a Module
+/// ==================
+///
+/// A module can be created using `init(name:context:)`.
+/// Note that the default target triple is bare metal and there is no default data layout.
+/// If you require these to be specified (e.g. to increase the correctness of default alignment values),
+/// be sure to set them yourself.
+///
+///     if let machine = try? TargetMachine() {
+///         module.targetTriple = machine.triple
+///         module.dataLayout = machine.dataLayout
+///     }
+///
 /// Verifying a Module
 /// ==================
 ///

--- a/Sources/LLVM/Units.swift
+++ b/Sources/LLVM/Units.swift
@@ -27,6 +27,7 @@ public struct Alignment: Comparable, Hashable {
   ///
   /// An n-byte alignment contains log-base-two-many least-significant zeros.
   public func log2() -> UInt32 {
+    guard !isZero else { return 0 }
     return 31 - UInt32(self.rawValue.leadingZeroBitCount)
   }
 
@@ -34,7 +35,9 @@ public struct Alignment: Comparable, Hashable {
   ///
   /// An n-byte alignment contains log-base-two-many least-significant zeros.
   public func log2() -> UInt64 {
-    return 63 - UInt64(self.rawValue.leadingZeroBitCount)
+    guard !isZero else { return 0 }
+    // rawValue is only 32 bits
+    return 31 - UInt64(self.rawValue.leadingZeroBitCount)
   }
   
   /// Returns the alignment of a pointer which points to the given number of

--- a/Tests/LLVMTests/BFC.swift
+++ b/Tests/LLVMTests/BFC.swift
@@ -261,11 +261,13 @@ private func compileProgramBody(
                                           encoding: .signed, flags: [],
                                           size: builder.module.dataLayout.abiSize(of: cellType))
   let diPtrTy = dibuilder.buildPointerType(pointee: diDataTy,
-                                           size: builder.module.dataLayout.pointerSize())
+                                            size: builder.module.dataLayout.pointerSize(),
+                                           alignment: .one)
   let diVariable = dibuilder.buildLocalVariable(named: "this",
                                                 scope: entryScope,
                                                 file: file, line: startPoint.0,
-                                                type: diPtrTy, flags: .artificial)
+                                                type: diPtrTy, flags: .artificial,
+                                                alignment: .one)
 
   var sourceLine = startPoint.0 + 1
   var sourceColumn = startPoint.1 + 1

--- a/Tests/LLVMTests/BFC.swift
+++ b/Tests/LLVMTests/BFC.swift
@@ -261,7 +261,7 @@ private func compileProgramBody(
                                           encoding: .signed, flags: [],
                                           size: builder.module.dataLayout.abiSize(of: cellType))
   let diPtrTy = dibuilder.buildPointerType(pointee: diDataTy,
-                                            size: builder.module.dataLayout.pointerSize(),
+                                           size: builder.module.dataLayout.pointerSize(),
                                            alignment: .one)
   let diVariable = dibuilder.buildLocalVariable(named: "this",
                                                 scope: entryScope,

--- a/Tests/LLVMTests/DIBuilderSpec.swift
+++ b/Tests/LLVMTests/DIBuilderSpec.swift
@@ -47,7 +47,7 @@ class DIBuilderSpec : XCTestCase {
       // DIEXPRESSION: !{{[0-9]+}} = !DIGlobalVariableExpression(var: !{{[0-9]+}}, expr: !{{[0-9]+}})
       let expr = debugBuilder.buildGlobalExpression(
         named: "global", linkageName: "global", type: globalTy,
-        scope: cu, file: file, line: 42)
+        scope: cu, file: file, line: 42, alignment: global.alignment)
       // DIEXPRESSION: !{{[0-9]+}} = distinct !DIGlobalVariable(name: "unattached", linkageName: "unattached", scope: !0, file: !{{[0-9]+}}, line: 42, type: !{{[0-9]+}}, isLocal: true, isDefinition: true)
       _ = debugBuilder.buildGlobalExpression(
         named: "unattached", linkageName: "unattached",

--- a/Tests/LLVMTests/IRAttributesSpec.swift
+++ b/Tests/LLVMTests/IRAttributesSpec.swift
@@ -14,7 +14,7 @@ class IRAttributesSpec : XCTestCase {
                                    type: FunctionType([IntType.int32, IntType.int32],
                                                       IntType.int32))
 
-      // FNATTR: define i32 @fn(i32, i32) #0 {
+      // FNATTR: define i32 @fn(i32 %0, i32 %1) #0 {
       fn.addAttribute(.nounwind, to: .function)
 
       // FNATTR-NEXT: entry:
@@ -36,7 +36,7 @@ class IRAttributesSpec : XCTestCase {
                                    type: FunctionType([IntType.int32, IntType.int32],
                                                       IntType.int32))
 
-      // RVATTR: define signext i32 @fn(i32, i32) {
+      // RVATTR: define signext i32 @fn(i32 %0, i32 %1) {
       fn.addAttribute(.signext, to: .returnValue)
 
       // RVATTR-NEXT: entry:
@@ -58,7 +58,7 @@ class IRAttributesSpec : XCTestCase {
                                    type: FunctionType([IntType.int32, i8ptr],
                                                       IntType.int32))
 
-      // ARGATTR: define i32 @fn(i32 zeroext, i8* align 8) {
+      // ARGATTR: define i32 @fn(i32 zeroext %0, i8* align 8 %1) {
       fn.addAttribute(.zeroext, to: .argument(0))
       fn.addAttribute(.align, value: 8, to: .argument(1))
 

--- a/Tests/LLVMTests/IRIntrinsicSpec.swift
+++ b/Tests/LLVMTests/IRIntrinsicSpec.swift
@@ -13,7 +13,7 @@ class IRIntrinsicSpec : XCTestCase {
       let module = Module(name: "IRIntrinsicTest")
       let builder = IRBuilder(module: module)
 
-      // IRINTRINSIC: define i32 @readOneArg(i32, ...) {
+      // IRINTRINSIC: define i32 @readOneArg(i32 %0, ...) {
       let main = builder.addFunction("readOneArg",
                                      type: FunctionType([IntType.int32],
                                                         IntType.int32,
@@ -53,13 +53,13 @@ class IRIntrinsicSpec : XCTestCase {
       module.dump()
 
       // IRINTRINSIC: ; Function Attrs: nounwind
-      // IRINTRINSIC-NEXT: declare void @llvm.va_start(i8*) #0
+      // IRINTRINSIC-NEXT: declare void @llvm.va_start(i8* %0) #0
 
       // IRINTRINSIC: ; Function Attrs: nounwind
-      // IRINTRINSIC-NEXT: declare void @llvm.va_copy(i8*, i8*) #0
+      // IRINTRINSIC-NEXT: declare void @llvm.va_copy(i8* %0, i8* %1) #0
 
       // IRINTRINSIC: ; Function Attrs: nounwind
-      // IRINTRINSIC-NEXT: declare void @llvm.va_end(i8*) #0
+      // IRINTRINSIC-NEXT: declare void @llvm.va_end(i8* %0) #0
     })
 
     XCTAssert(fileCheckOutput(of: .stderr, withPrefixes: ["VIRTUALOVERLOAD-IRINTRINSIC"]) {
@@ -93,7 +93,7 @@ class IRIntrinsicSpec : XCTestCase {
       module.dump()
 
       // VIRTUALOVERLOAD-IRINTRINSIC: ; Function Attrs: nounwind readnone
-      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: declare i32* @llvm.ssa.copy.p0i32(i32* returned) #0
+      // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: declare i32* @llvm.ssa.copy.p0i32(i32* returned %0) #0
     })
 
     XCTAssert(fileCheckOutput(of: .stderr, withPrefixes: ["INTRINSIC-FAMILY-RESOLVE"]) {

--- a/Tests/LLVMTests/IRMetadataSpec.swift
+++ b/Tests/LLVMTests/IRMetadataSpec.swift
@@ -180,7 +180,7 @@ class IRMetadataSpec : XCTestCase {
         IntType.int32.constant(0), // .s
       ])
       // B->a.s = 42
-      // IRSIMPLETBAA-NEXT:  store i16 42, i16* %1, !tbaa [[AccessTag:![0-9]+]]
+      // IRSIMPLETBAA-NEXT:  store i16 42, i16* %1, align 2, !tbaa [[AccessTag:![0-9]+]]
       let si = builder.buildStore(IntType.int16.constant(42), to: field)
       // IRSIMPLETBAA-NEXT:  ret void
       builder.buildRetVoid()

--- a/Tests/LLVMTests/IRMetadataSpec.swift
+++ b/Tests/LLVMTests/IRMetadataSpec.swift
@@ -63,7 +63,7 @@ class IRMetadataSpec : XCTestCase {
       XCTAssertNil(builder.defaultFloatingPointMathTag)
       builder.defaultFloatingPointMathTag = MDB.buildFloatingPointMathTag(0.1)
 
-      // IRFPMATHMETADATA: define float @test(float, float) {
+      // IRFPMATHMETADATA: define float @test(float %0, float %1) {
       let main = builder.addFunction("test",
                                      type: FunctionType([
                                        FloatType.float, FloatType.float
@@ -91,7 +91,7 @@ class IRMetadataSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       let MDB = MDBuilder()
 
-      // IRBWMETADATA: define float @test(i1, float, float) {
+      // IRBWMETADATA: define float @test(i1 %0, float %1, float %2) {
       let main = builder.addFunction("test",
                                      type: FunctionType([
                                        IntType.int1,
@@ -226,7 +226,7 @@ class IRMetadataSpec : XCTestCase {
       let builder = IRBuilder(module: module)
       let MDB = MDBuilder()
 
-      // IRMEMTRANSFERTBAA: define void @main(i8*) {
+      // IRMEMTRANSFERTBAA: define void @main(i8* %0) {
       let F = module.addFunction("main", type: FunctionType([PointerType.toVoid], VoidType()))
       // IRMEMTRANSFERTBAA-NEXT: entry:
       let bb = F.appendBasicBlock(named: "entry")

--- a/Tests/LLVMTests/IRPassManagerSpec.swift
+++ b/Tests/LLVMTests/IRPassManagerSpec.swift
@@ -109,7 +109,7 @@ class IRPassManagerSpec : XCTestCase {
       // CHECK-EXECUTE-STDOPT:  ; ModuleID = 'Test'
       // CHECK-EXECUTE-STDOPT:  source_filename = "Test"
 
-      // CHECK-EXECUTE-STDOPT:  define i32 @fun(i32, i32) {
+      // CHECK-EXECUTE-STDOPT:  define i32 @fun(i32 %0, i32 %1) {
       // CHECK-EXECUTE-STDOPT:    entry:
       // CHECK-EXECUTE-STDOPT:    %2 = alloca i32, align 4
       // CHECK-EXECUTE-STDOPT:    %3 = alloca i32, align 4
@@ -148,7 +148,7 @@ class IRPassManagerSpec : XCTestCase {
       // CHECK-EXECUTE-STDOPT: source_filename = "Test"
 
       // CHECK-EXECUTE-STDOPT: ; Function Attrs: norecurse nounwind readnone
-      // CHECK-EXECUTE-STDOPT: define i32 @fun(i32, i32) local_unnamed_addr #0 {
+      // CHECK-EXECUTE-STDOPT: define i32 @fun(i32 %0, i32 %1) local_unnamed_addr #0 {
       // CHECK-EXECUTE-STDOPT:   entry:
       // CHECK-EXECUTE-STDOPT:   %2 = icmp eq i32 %0, 1
       // CHECK-EXECUTE-STDOPT:   %3 = add nsw i32 %1, 4
@@ -174,7 +174,7 @@ class IRPassManagerSpec : XCTestCase {
       // CHECK-EXECUTE-MASK:  ; ModuleID = 'Test'
       // CHECK-EXECUTE-MASK:  source_filename = "Test"
 
-      // CHECK-EXECUTE-MASK:  define i32 @fun(i32, i32) {
+      // CHECK-EXECUTE-MASK:  define i32 @fun(i32 %0, i32 %1) {
       // CHECK-EXECUTE-MASK:    entry:
       // CHECK-EXECUTE-MASK:    %2 = alloca i32, align 4
       // CHECK-EXECUTE-MASK:    %3 = alloca i32, align 4
@@ -212,7 +212,7 @@ class IRPassManagerSpec : XCTestCase {
       // CHECK-EXECUTE-MASK:  ; ModuleID = 'Test'
       // CHECK-EXECUTE-MASK:  source_filename = "Test"
 
-      // CHECK-EXECUTE-MASK:  define i32 @fun(i32, i32) {
+      // CHECK-EXECUTE-MASK:  define i32 @fun(i32 %0, i32 %1) {
       // CHECK-EXECUTE-MASK:    entry:
       // CHECK-EXECUTE-MASK:    %2 = alloca i32, align 4
       // CHECK-EXECUTE-MASK:    %3 = alloca i32, align 4


### PR DESCRIPTION
Resolves #225.

Two issues needed addressed.

## Argument Auto-Generated Names
Per LLVM 10.0 [release notes](https://releases.llvm.org/10.0.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir):
> Unnamed function arguments now get printed with their automatically generated name (e.g. “i32 %0”) in definitions. This may require front-ends to update their tests; if so there is a script utils/add_argument_names.py that correctly converted 80-90% of Clang tests. Some manual work will almost certainly still be needed.

For example, IR that used to be:
```
define i32 @fn(i32 zeroext, i8* align 8)
```
becomes:
```
define i32 @fn(i32 zeroext %0, i8* align 8 %1)
```

Solution: Update file check statements to include argument names.

## Default Alignments
Couldn't find it mentioned in the release notes, but a recent LLVM seems to have changed the spec for `alloca`, `load`, and `store` such that `align` is now required to be specified in the IR with the alignment value. (See [here](https://reviews.llvm.org/D80044).) Functions such as `LLVMBuildAlloca` will now auto-generate an alignment, although one can be explicitly specified via `LLVMSetAlignment`.

Unfortunately, with this change, calling `LLVMSetAlignment` with an alignment of 0 is unsupported (this could be a bug in LLVM). When 0 is passed, internally LLVM now wraps it in an `Align` rather than a `MaybeAlign` and does not perform a 0 check (see [here](https://reviews.llvm.org/D80044#change-QoLYiwlyMGmS).). Eventually, `Log2` is called on the alignment, and the shortcut for Log2 (e.g. 31 - leading zero bit count) results in an overflow of the unsigned integer. This causes a very large alignment value and module verification fails.

Solution: Keep the generated alignment value from methods like `LLVMBuildAlloca` and only explicit set one when non-zero.