### PR TITLE
Force unwrap the result of 'strdup'

### DIFF
--- a/Sources/LLVM/Module.swift
+++ b/Sources/LLVM/Module.swift
@@ -292,7 +292,7 @@ extension Module {
     path.withCString { cString in
       let mutable = strdup(cString)
       LLVMPrintModuleToFile(llvm, mutable, &err)
-      free(mutable)
+      free(mutable!)
     }
     if let err = err {
       defer { LLVMDisposeMessage(err) }
@@ -325,7 +325,7 @@ extension Module {
   public func emitBitCode(to path: String) throws {
     let status = path.withCString { cString -> Int32 in
       let mutable = strdup(cString)
-      defer { free(mutable) }
+      defer { free(mutable!) }
       return LLVMWriteBitcodeToFile(llvm, mutable)
     }
 

--- a/Sources/LLVM/TargetMachine.swift
+++ b/Sources/LLVM/TargetMachine.swift
@@ -239,7 +239,7 @@ public class TargetMachine {
     var err: UnsafeMutablePointer<Int8>?
     let status = path.withCString { cStr -> LLVMBool in
       let mutable = strdup(cStr)
-      defer { free(mutable) }
+      defer { free(mutable!) }
       return LLVMTargetMachineEmitToFile(llvm, module.llvm, mutable, type.asLLVM(), &err)
     }
     if let err = err, status != 0 {


### PR DESCRIPTION
It appears the API of `free` has changed with Swift 5.5, and the function does no longer accepts an optional pointer.

This pull request only force-unwrap the result of `strdup` that are passed to `free`.