### PR TITLE
Initial support for LLVM 13 (disabled JIT for now)

### DIFF
--- a/Sources/LLVM/Comdat.swift
+++ b/Sources/LLVM/Comdat.swift
@@ -88,12 +88,8 @@ extension Comdat {
     /// The linker chooses the identically-keyed COMDAT section with the largest
     /// size, ignoring content.
     case largest
-    /// The COMDAT section with this key is unique.
-    ///
-    /// This selection requires that no other COMDAT section have the same key
-    /// as this section, making the choice of selection unambiguous.  Inclusion
-    /// of any other COMDAT section with the same key is an error.
-    case noDuplicates
+    /// No deduplication is performed.
+    case noDeduplicate
     /// The linker may choose any identically-keyed COMDAT section and requires
     /// all other sections to have the same size as its selection.
     case sameSize
@@ -103,7 +99,7 @@ extension Comdat {
       case LLVMAnyComdatSelectionKind: self = .any
       case LLVMExactMatchComdatSelectionKind: self = .exactMatch
       case LLVMLargestComdatSelectionKind: self = .largest
-      case LLVMNoDuplicatesComdatSelectionKind: self = .noDuplicates
+      case LLVMNoDeduplicateComdatSelectionKind: self = .noDeduplicate
       case LLVMSameSizeComdatSelectionKind: self = .sameSize
       default: fatalError("unknown comdat selection kind \(llvm)")
       }
@@ -113,7 +109,7 @@ extension Comdat {
       .any: LLVMAnyComdatSelectionKind,
       .exactMatch: LLVMExactMatchComdatSelectionKind,
       .largest: LLVMLargestComdatSelectionKind,
-      .noDuplicates: LLVMNoDuplicatesComdatSelectionKind,
+      .noDeduplicate: LLVMNoDeduplicateComdatSelectionKind,
       .sameSize: LLVMSameSizeComdatSelectionKind,
     ]
 

--- a/Sources/LLVM/IRBuilder.swift
+++ b/Sources/LLVM/IRBuilder.swift
@@ -1910,13 +1910,15 @@ extension IRBuilder {
   ///   side effects.  Defaults to `false`.
   /// - parameter needsAlignedStack: Whether the function containing the
   ///   asm needs to align its stack conservatively.  Defaults to `true`.
+  /// - parameter canThrow: Whether the function containing the
+  ///   asm can throw.  Defaults to `false`.
   ///
   /// - returns: A representation of the newly created inline assembly
   ///   expression.
   public func buildInlineAssembly(
     _ asm: String, dialect: InlineAssemblyDialect, type: FunctionType,
     constraints: String = "",
-    hasSideEffects: Bool = true, needsAlignedStack: Bool = true
+    hasSideEffects: Bool = true, needsAlignedStack: Bool = true, canThrow: Bool = false
   ) -> IRValue {
     var asm = asm.utf8CString
     var constraints = constraints.utf8CString
@@ -1926,7 +1928,7 @@ extension IRBuilder {
                                 asm.baseAddress, asm.count,
                                 constraints.baseAddress, constraints.count,
                                 hasSideEffects.llvm, needsAlignedStack.llvm,
-                                dialect.llvm)
+                                dialect.llvm, canThrow.llvm)
       }
     }
   }

--- a/Sources/LLVM/JIT.swift
+++ b/Sources/LLVM/JIT.swift
@@ -1,23 +1,23 @@
 #if SWIFT_PACKAGE
-import cllvm
+  import cllvm
 #endif
 
 /// JITError represents the different kinds of errors the JIT compiler can
 /// throw.
-public enum JITError: Error, CustomStringConvertible {
-  /// A generic error thrown by the JIT during exceptional circumstances.
-  ///
-  /// In general, it is not safe to catch and continue after this exception has
-  /// been thrown.
-  case generic(String)
+// public enum JITError: Error, CustomStringConvertible {
+//   /// A generic error thrown by the JIT during exceptional circumstances.
+//   ///
+//   /// In general, it is not safe to catch and continue after this exception has
+//   /// been thrown.
+//   case generic(String)
 
-  public var description: String {
-    switch self {
-    case let .generic(desc):
-      return desc
-    }
-  }
-}
+//   public var description: String {
+//     switch self {
+//     case let .generic(desc):
+//       return desc
+//     }
+//   }
+// }
 
 /// A `JIT` is a Just-In-Time compiler that will compile and execute LLVM IR
 /// that has been generated in a `Module`. It can execute arbitrary functions
@@ -30,7 +30,7 @@ public final class JIT {
   /// A type that represents an address, either symbolically within the JIT or
   /// physically in the execution environment.
   public struct TargetAddress: Comparable {
-    fileprivate var llvm: LLVMOrcTargetAddress
+    fileprivate var llvm: LLVMOrcJITTargetAddress
 
     /// Creates a target address value of `0`.
     public init() {
@@ -38,7 +38,7 @@ public final class JIT {
     }
 
     /// Creates a target address from a raw address value.
-    public init(raw: LLVMOrcTargetAddress) {
+    public init(raw: LLVMOrcJITTargetAddress) {
       self.llvm = raw
     }
 
@@ -52,264 +52,259 @@ public final class JIT {
   }
 
   /// Represents a handle to a module owned by the JIT stack.
-  public struct ModuleHandle {
-    fileprivate var llvm: LLVMOrcModuleHandle
-  }
+  // public struct ModuleHandle {
+  //   fileprivate var llvm: LLVMOrcModuleHandle
+  // }
 
   /// The underlying LLVMExecutionEngineRef backing this JIT.
-  internal let llvm: LLVMOrcJITStackRef
+  internal let llvm: LLVMOrcLLJITBuilderRef
   private let ownsContext: Bool
 
-  internal init(llvm: LLVMOrcJITStackRef, ownsContext: Bool) {
+  internal init(llvm: LLVMOrcLLJITBuilderRef, ownsContext: Bool) {
     self.llvm = llvm
     self.ownsContext = ownsContext
   }
 
   /// Create and initialize a `JIT` with this target machine's representation.
   public convenience init(machine: TargetMachine) {
-    // The JIT stack takes ownership of the target machine.
-    machine.ownsContext = false
-    self.init(llvm: LLVMOrcCreateInstance(machine.llvm), ownsContext: true)
+    self.init(llvm: LLVMOrcCreateLLJITBuilder(), ownsContext: true)
   }
 
-  /// Deinitialize this value and dispose of its resources.
+  // /// Deinitialize this value and dispose of its resources.
   deinit {
-    guard self.ownsContext else {
-      return
-    }
-    _ = LLVMOrcDisposeInstance(self.llvm)
+    LLVMOrcDisposeLLJITBuilder(self.llvm)
   }
 
-  // MARK: Symbols
+  // // MARK: Symbols
 
-  /// Mangles the given symbol name according to the data layout of the JIT's
-  /// target machine.
-  ///
-  /// - parameter symbol: The symbol name to mangle.
-  /// - returns: A mangled representation of the given symbol name.
-  public func mangle(symbol: String) -> String {
-    var mangledResult: UnsafeMutablePointer<Int8>? = nil
-    LLVMOrcGetMangledSymbol(self.llvm, &mangledResult, symbol)
-    guard let result = mangledResult else {
-      fatalError("Mangled name should never be nil!")
-    }
-    defer { LLVMOrcDisposeMangledSymbol(mangledResult) }
-    return String(cString: result)
-  }
+  // /// Mangles the given symbol name according to the data layout of the JIT's
+  // /// target machine.
+  // ///
+  // /// - parameter symbol: The symbol name to mangle.
+  // /// - returns: A mangled representation of the given symbol name.
+  // public func mangle(symbol: String) -> String {
+  //   var mangledResult: UnsafeMutablePointer<Int8>? = nil
+  //   LLVMOrcGetMangledSymbol(self.llvm, &mangledResult, symbol)
+  //   guard let result = mangledResult else {
+  //     fatalError("Mangled name should never be nil!")
+  //   }
+  //   defer { LLVMOrcDisposeMangledSymbol(mangledResult) }
+  //   return String(cString: result)
+  // }
 
-  /// Computes the address of the given symbol, optionally restricting the
-  /// search for its address to a particular module.  If this symbol does not
-  /// exist, an address of `0` is returned.
-  ///
-  /// - parameter symbol: The symbol name to search for.
-  /// - parameter module: An optional value describing the module in which to
-  ///   restrict the search, if any.
-  /// - returns: The address of the symbol, or 0 if it does not exist.
-  public func address(of symbol: String, in module: ModuleHandle? = nil) throws -> TargetAddress {
-    var retAddr: LLVMOrcTargetAddress = 0
-    if let targetModule = module {
-      try checkForJITError(LLVMOrcGetSymbolAddressIn(self.llvm, &retAddr, targetModule.llvm, symbol))
-    } else {
-      try checkForJITError(LLVMOrcGetSymbolAddress(self.llvm, &retAddr, symbol))
-    }
-    return TargetAddress(raw: retAddr)
-  }
+  // /// Computes the address of the given symbol, optionally restricting the
+  // /// search for its address to a particular module.  If this symbol does not
+  // /// exist, an address of `0` is returned.
+  // ///
+  // /// - parameter symbol: The symbol name to search for.
+  // /// - parameter module: An optional value describing the module in which to
+  // ///   restrict the search, if any.
+  // /// - returns: The address of the symbol, or 0 if it does not exist.
+  // public func address(of symbol: String, in module: ModuleHandle? = nil) throws -> TargetAddress {
+  //   var retAddr: LLVMOrcTargetAddress = 0
+  //   if let targetModule = module {
+  //     try checkForJITError(LLVMOrcGetSymbolAddressIn(self.llvm, &retAddr, targetModule.llvm, symbol))
+  //   } else {
+  //     try checkForJITError(LLVMOrcGetSymbolAddress(self.llvm, &retAddr, symbol))
+  //   }
+  //   return TargetAddress(raw: retAddr)
+  // }
 
-  // MARK: Lazy Compilation
+  // // MARK: Lazy Compilation
 
-  /// Registers a lazy compile callback that can be used to get the target
-  /// address of a trampoline function.  When that trampoline address is
-  /// called, the given compilation callback is fired.
-  ///
-  /// Normally, the trampoline function is a known stub that has been previously
-  /// registered with the JIT.  The callback then computes the address of a
-  /// known entry point and sets the address of the stub to it. See
-  /// `JIT.createIndirectStub` to create a stub function and
-  /// `JIT.setIndirectStubPointer` to set the address of a stub.
-  ///
-  /// - parameter callback: A callback that returns the actual address of the
-  ///   trampoline function.
-  /// - returns: The target address representing a stub.  Calling this stub
-  ///   forces the given compilation callback to fire.
-  public func registerLazyCompile(_ callback: @escaping (JIT) -> TargetAddress) throws -> TargetAddress {
-    var addr: LLVMOrcTargetAddress = 0
-    let callbackContext = ORCLazyCompileCallbackContext(callback)
-    let contextPtr = Unmanaged<ORCLazyCompileCallbackContext>.passRetained(callbackContext).toOpaque()
-    try checkForJITError(LLVMOrcCreateLazyCompileCallback(self.llvm, &addr, lazyCompileBlockTrampoline, contextPtr))
-    return TargetAddress(raw: addr)
-  }
+  // /// Registers a lazy compile callback that can be used to get the target
+  // /// address of a trampoline function.  When that trampoline address is
+  // /// called, the given compilation callback is fired.
+  // ///
+  // /// Normally, the trampoline function is a known stub that has been previously
+  // /// registered with the JIT.  The callback then computes the address of a
+  // /// known entry point and sets the address of the stub to it. See
+  // /// `JIT.createIndirectStub` to create a stub function and
+  // /// `JIT.setIndirectStubPointer` to set the address of a stub.
+  // ///
+  // /// - parameter callback: A callback that returns the actual address of the
+  // ///   trampoline function.
+  // /// - returns: The target address representing a stub.  Calling this stub
+  // ///   forces the given compilation callback to fire.
+  // public func registerLazyCompile(_ callback: @escaping (JIT) -> TargetAddress) throws -> TargetAddress {
+  //   var addr: LLVMOrcTargetAddress = 0
+  //   let callbackContext = ORCLazyCompileCallbackContext(callback)
+  //   let contextPtr = Unmanaged<ORCLazyCompileCallbackContext>.passRetained(callbackContext).toOpaque()
+  //   try checkForJITError(LLVMOrcCreateLazyCompileCallback(self.llvm, &addr, lazyCompileBlockTrampoline, contextPtr))
+  //   return TargetAddress(raw: addr)
+  // }
 
-  // MARK: Stubs
+  // // MARK: Stubs
 
-  /// Creates a new named indirect stub pointing to the given target address.
-  ///
-  /// An indirect stub may be resolved to a different address at any time by
-  /// invoking `JIT.setIndirectStubPointer`.
-  ///
-  /// - parameter name: The name of the indirect stub.
-  /// - parameter address: The address of the indirect stub.
-  public func createIndirectStub(named name: String, address: TargetAddress) throws {
-    try checkForJITError(LLVMOrcCreateIndirectStub(self.llvm, name, address.llvm))
-  }
+  // /// Creates a new named indirect stub pointing to the given target address.
+  // ///
+  // /// An indirect stub may be resolved to a different address at any time by
+  // /// invoking `JIT.setIndirectStubPointer`.
+  // ///
+  // /// - parameter name: The name of the indirect stub.
+  // /// - parameter address: The address of the indirect stub.
+  // public func createIndirectStub(named name: String, address: TargetAddress) throws {
+  //   try checkForJITError(LLVMOrcCreateIndirectStub(self.llvm, name, address.llvm))
+  // }
 
-  /// Resets the address of an indirect stub.
-  ///
-  /// - warning: The indirect stub must be registered with a call to
-  ///   `JIT.createIndirectStub`.  Failure to do so will result in undefined
-  ///   behavior.
-  ///
-  /// - parameter name: The name of an indirect stub.
-  /// - parameter address: The address to set the indirect stub to point to.
-  public func setIndirectStubPointer(named name: String, address: TargetAddress) throws {
-    try checkForJITError(LLVMOrcSetIndirectStubPointer(self.llvm, name, address.llvm))
-  }
+  // /// Resets the address of an indirect stub.
+  // ///
+  // /// - warning: The indirect stub must be registered with a call to
+  // ///   `JIT.createIndirectStub`.  Failure to do so will result in undefined
+  // ///   behavior.
+  // ///
+  // /// - parameter name: The name of an indirect stub.
+  // /// - parameter address: The address to set the indirect stub to point to.
+  // public func setIndirectStubPointer(named name: String, address: TargetAddress) throws {
+  //   try checkForJITError(LLVMOrcSetIndirectStubPointer(self.llvm, name, address.llvm))
+  // }
 
-  // MARK: Adding Code to the JIT
+  // // MARK: Adding Code to the JIT
 
-  /// Adds the IR from a given module to the JIT, consuming it in the process.
-  ///
-  /// Despite the name of this function, the callback to compile the symbols in
-  /// the module is not necessarily called immediately.  It is called at least
-  /// when a given symbol's address is requested, either by the JIT or by
-  /// the user e.g. `JIT.address(of:)`.
-  ///
-  /// The callback function is required to compute the address of the given
-  /// symbol.  The symbols are passed in mangled form.  Use
-  /// `JIT.mangle(symbol:)` to request the mangled name of a symbol.
-  ///
-  /// - warning: The JIT invalidates the underlying reference to the provided
-  ///   module.  Further references to the module are thus dangling pointers and
-  ///   may be a source of subtle memory bugs.  This will be addressed in a
-  ///   future revision of LLVM.
-  ///
-  /// - parameter module: The module to compile.
-  /// - parameter callback: A function that is called by the JIT to compute the
-  ///   address of symbols.
-  public func addEagerlyCompiledIR(_ module: Module, _ callback: @escaping (String) -> TargetAddress) throws -> ModuleHandle {
-    var handle: LLVMOrcModuleHandle = 0
-    let callbackContext = ORCSymbolCallbackContext(callback)
-    let contextPtr = Unmanaged<ORCSymbolCallbackContext>.passRetained(callbackContext).toOpaque()
-    // The JIT stack takes ownership of the given module.
-    module.ownsContext = false
-    try checkForJITError(LLVMOrcAddEagerlyCompiledIR(self.llvm, &handle, module.llvm, symbolBlockTrampoline, contextPtr))
-    return ModuleHandle(llvm: handle)
-  }
+  // /// Adds the IR from a given module to the JIT, consuming it in the process.
+  // ///
+  // /// Despite the name of this function, the callback to compile the symbols in
+  // /// the module is not necessarily called immediately.  It is called at least
+  // /// when a given symbol's address is requested, either by the JIT or by
+  // /// the user e.g. `JIT.address(of:)`.
+  // ///
+  // /// The callback function is required to compute the address of the given
+  // /// symbol.  The symbols are passed in mangled form.  Use
+  // /// `JIT.mangle(symbol:)` to request the mangled name of a symbol.
+  // ///
+  // /// - warning: The JIT invalidates the underlying reference to the provided
+  // ///   module.  Further references to the module are thus dangling pointers and
+  // ///   may be a source of subtle memory bugs.  This will be addressed in a
+  // ///   future revision of LLVM.
+  // ///
+  // /// - parameter module: The module to compile.
+  // /// - parameter callback: A function that is called by the JIT to compute the
+  // ///   address of symbols.
+  // public func addEagerlyCompiledIR(_ module: Module, _ callback: @escaping (String) -> TargetAddress) throws -> ModuleHandle {
+  //   var handle: LLVMOrcModuleHandle = 0
+  //   let callbackContext = ORCSymbolCallbackContext(callback)
+  //   let contextPtr = Unmanaged<ORCSymbolCallbackContext>.passRetained(callbackContext).toOpaque()
+  //   // The JIT stack takes ownership of the given module.
+  //   module.ownsContext = false
+  //   try checkForJITError(LLVMOrcAddEagerlyCompiledIR(self.llvm, &handle, module.llvm, symbolBlockTrampoline, contextPtr))
+  //   return ModuleHandle(llvm: handle)
+  // }
 
-  /// Adds the IR from a given module to the JIT, consuming it in the process.
-  ///
-  /// This function differs from `JIT.addEagerlyCompiledIR` in that the callback
-  /// to request the address of symbols is only executed when that symbol is
-  /// called, either in user code or by the JIT.
-  ///
-  /// The callback function is required to compute the address of the given
-  /// symbol.  The symbols are passed in mangled form.  Use
-  /// `JIT.mangle(symbol:)` to request the mangled name of a symbol.
-  ///
-  /// - warning: The JIT invalidates the underlying reference to the provided
-  ///   module.  Further references to the module are thus dangling pointers and
-  ///   may be a source of subtle memory bugs.  This will be addressed in a
-  ///   future revision of LLVM.
-  ///
-  /// - parameter module: The module to compile.
-  /// - parameter callback: A function that is called by the JIT to compute the
-  ///   address of symbols.
-  public func addLazilyCompiledIR(_ module: Module, _ callback: @escaping (String) -> TargetAddress) throws -> ModuleHandle {
-    var handle: LLVMOrcModuleHandle = 0
-    let callbackContext = ORCSymbolCallbackContext(callback)
-    let contextPtr = Unmanaged<ORCSymbolCallbackContext>.passRetained(callbackContext).toOpaque()
-    // The JIT stack takes ownership of the given module.
-    module.ownsContext = false
-    try checkForJITError(LLVMOrcAddLazilyCompiledIR(self.llvm, &handle, module.llvm, symbolBlockTrampoline, contextPtr))
-    return ModuleHandle(llvm: handle)
-  }
+  // /// Adds the IR from a given module to the JIT, consuming it in the process.
+  // ///
+  // /// This function differs from `JIT.addEagerlyCompiledIR` in that the callback
+  // /// to request the address of symbols is only executed when that symbol is
+  // /// called, either in user code or by the JIT.
+  // ///
+  // /// The callback function is required to compute the address of the given
+  // /// symbol.  The symbols are passed in mangled form.  Use
+  // /// `JIT.mangle(symbol:)` to request the mangled name of a symbol.
+  // ///
+  // /// - warning: The JIT invalidates the underlying reference to the provided
+  // ///   module.  Further references to the module are thus dangling pointers and
+  // ///   may be a source of subtle memory bugs.  This will be addressed in a
+  // ///   future revision of LLVM.
+  // ///
+  // /// - parameter module: The module to compile.
+  // /// - parameter callback: A function that is called by the JIT to compute the
+  // ///   address of symbols.
+  // public func addLazilyCompiledIR(_ module: Module, _ callback: @escaping (String) -> TargetAddress) throws -> ModuleHandle {
+  //   var handle: LLVMOrcModuleHandle = 0
+  //   let callbackContext = ORCSymbolCallbackContext(callback)
+  //   let contextPtr = Unmanaged<ORCSymbolCallbackContext>.passRetained(callbackContext).toOpaque()
+  //   // The JIT stack takes ownership of the given module.
+  //   module.ownsContext = false
+  //   try checkForJITError(LLVMOrcAddLazilyCompiledIR(self.llvm, &handle, module.llvm, symbolBlockTrampoline, contextPtr))
+  //   return ModuleHandle(llvm: handle)
+  // }
 
-  /// Adds the executable code from an object file to ths JIT, consuming it in
-  /// the process.
-  ///
-  /// The callback function is required to compute the address of the given
-  /// symbol.  The symbols are passed in mangled form.  Use
-  /// `JIT.mangle(symbol:)` to request the mangled name of a symbol.
-  ///
-  /// - warning: The JIT invalidates the underlying reference to the provided
-  ///   memory buffer.  Further references to the buffer are thus dangling
-  ///   pointers and may be a source of subtle memory bugs.  This will be
-  ///   addressed in a future revision of LLVM.
-  ///
-  /// - parameter buffer: A buffer containing an object file.
-  /// - parameter callback: A function that is called by the JIT to compute the
-  ///   address of symbols.
-  public func addObjectFile(_ buffer: MemoryBuffer, _ callback: @escaping (String) -> TargetAddress) throws -> ModuleHandle {
-    var handle: LLVMOrcModuleHandle = 0
-    let callbackContext = ORCSymbolCallbackContext(callback)
-    let contextPtr = Unmanaged<ORCSymbolCallbackContext>.passRetained(callbackContext).toOpaque()
-    // The JIT stack takes ownership of the given buffer.
-    buffer.ownsContext = false
-    try checkForJITError(LLVMOrcAddObjectFile(self.llvm, &handle, buffer.llvm, symbolBlockTrampoline, contextPtr))
-    return ModuleHandle(llvm: handle)
-  }
+  // /// Adds the executable code from an object file to ths JIT, consuming it in
+  // /// the process.
+  // ///
+  // /// The callback function is required to compute the address of the given
+  // /// symbol.  The symbols are passed in mangled form.  Use
+  // /// `JIT.mangle(symbol:)` to request the mangled name of a symbol.
+  // ///
+  // /// - warning: The JIT invalidates the underlying reference to the provided
+  // ///   memory buffer.  Further references to the buffer are thus dangling
+  // ///   pointers and may be a source of subtle memory bugs.  This will be
+  // ///   addressed in a future revision of LLVM.
+  // ///
+  // /// - parameter buffer: A buffer containing an object file.
+  // /// - parameter callback: A function that is called by the JIT to compute the
+  // ///   address of symbols.
+  // public func addObjectFile(_ buffer: MemoryBuffer, _ callback: @escaping (String) -> TargetAddress) throws -> ModuleHandle {
+  //   var handle: LLVMOrcModuleHandle = 0
+  //   let callbackContext = ORCSymbolCallbackContext(callback)
+  //   let contextPtr = Unmanaged<ORCSymbolCallbackContext>.passRetained(callbackContext).toOpaque()
+  //   // The JIT stack takes ownership of the given buffer.
+  //   buffer.ownsContext = false
+  //   try checkForJITError(LLVMOrcAddObjectFile(self.llvm, &handle, buffer.llvm, symbolBlockTrampoline, contextPtr))
+  //   return ModuleHandle(llvm: handle)
+  // }
 
-  /// Remove previously-added code from the JIT.
-  ///
-  /// - warning: Removing a module handle consumes the handle.  Further use of
-  ///   the handle will then result in undefined behavior.
-  ///
-  /// - parameter handle: A handle to previously-added module.
-  public func removeModule(_ handle: ModuleHandle) throws {
-    try checkForJITError(LLVMOrcRemoveModule(self.llvm, handle.llvm))
-  }
+  // /// Remove previously-added code from the JIT.
+  // ///
+  // /// - warning: Removing a module handle consumes the handle.  Further use of
+  // ///   the handle will then result in undefined behavior.
+  // ///
+  // /// - parameter handle: A handle to previously-added module.
+  // public func removeModule(_ handle: ModuleHandle) throws {
+  //   try checkForJITError(LLVMOrcRemoveModule(self.llvm, handle.llvm))
+  // }
 
-  private func checkForJITError(_ orcError: LLVMErrorRef!) throws {
-    guard let err = orcError else {
-      return
-    }
+  // private func checkForJITError(_ orcError: LLVMErrorRef!) throws {
+  //   guard let err = orcError else {
+  //     return
+  //   }
 
-    switch LLVMGetErrorTypeId(err)! {
-    case LLVMGetStringErrorTypeId():
-      guard let msg = LLVMGetErrorMessage(err) else {
-        fatalError("Couldn't get the error message?")
-      }
-      throw JITError.generic(String(cString: msg))
-    default:
-      guard let msg = LLVMOrcGetErrorMsg(self.llvm) else {
-        fatalError("Couldn't get the error message?")
-      }
-      throw JITError.generic(String(cString: msg))
-    }
-  }
+  //   switch LLVMGetErrorTypeId(err)! {
+  //   case LLVMGetStringErrorTypeId():
+  //     guard let msg = LLVMGetErrorMessage(err) else {
+  //       fatalError("Couldn't get the error message?")
+  //     }
+  //     throw JITError.generic(String(cString: msg))
+  //   default:
+  //     guard let msg = LLVMOrcGetErrorMsg(self.llvm) else {
+  //       fatalError("Couldn't get the error message?")
+  //     }
+  //     throw JITError.generic(String(cString: msg))
+  //   }
+  // }
 }
 
-private let lazyCompileBlockTrampoline : LLVMOrcLazyCompileCallbackFn = { (callbackJIT, callbackCtx) in
-  guard let jit = callbackJIT, let ctx = callbackCtx else {
-    fatalError("Internal JIT callback and context must be non-nil")
-  }
+// private let lazyCompileBlockTrampoline : LLVMOrcLazyCompileCallbackFn = { (callbackJIT, callbackCtx) in
+//   guard let jit = callbackJIT, let ctx = callbackCtx else {
+//     fatalError("Internal JIT callback and context must be non-nil")
+//   }
 
-  let tempJIT = JIT(llvm: jit, ownsContext: false)
-  let callback = Unmanaged<ORCLazyCompileCallbackContext>.fromOpaque(ctx).takeUnretainedValue()
-  return callback.block(tempJIT).llvm
-}
+//   let tempJIT = JIT(llvm: jit, ownsContext: false)
+//   let callback = Unmanaged<ORCLazyCompileCallbackContext>.fromOpaque(ctx).takeUnretainedValue()
+//   return callback.block(tempJIT).llvm
+// }
 
-private let symbolBlockTrampoline : LLVMOrcSymbolResolverFn = { (callbackName, callbackCtx) in
-  guard let cname = callbackName, let ctx = callbackCtx else {
-    fatalError("Internal JIT name and context must be non-nil")
-  }
+// private let symbolBlockTrampoline : LLVMOrcSymbolResolverFn = { (callbackName, callbackCtx) in
+//   guard let cname = callbackName, let ctx = callbackCtx else {
+//     fatalError("Internal JIT name and context must be non-nil")
+//   }
 
-  let name = String(cString: cname)
-  let callback = Unmanaged<ORCSymbolCallbackContext>.fromOpaque(ctx).takeUnretainedValue()
-  return callback.block(name).llvm
-}
+//   let name = String(cString: cname)
+//   let callback = Unmanaged<ORCSymbolCallbackContext>.fromOpaque(ctx).takeUnretainedValue()
+//   return callback.block(name).llvm
+// }
 
-private class ORCLazyCompileCallbackContext {
-  fileprivate let block: (JIT) -> JIT.TargetAddress
+// private class ORCLazyCompileCallbackContext {
+//   fileprivate let block: (JIT) -> JIT.TargetAddress
 
-  fileprivate init(_ block: @escaping (JIT) -> JIT.TargetAddress) {
-    self.block = block
-  }
-}
+//   fileprivate init(_ block: @escaping (JIT) -> JIT.TargetAddress) {
+//     self.block = block
+//   }
+// }
 
-private class ORCSymbolCallbackContext {
-  fileprivate let block: (String) -> JIT.TargetAddress
+// private class ORCSymbolCallbackContext {
+//   fileprivate let block: (String) -> JIT.TargetAddress
 
-  fileprivate init(_ block: @escaping (String) -> JIT.TargetAddress) {
-    self.block = block
-  }
-}
+//   fileprivate init(_ block: @escaping (String) -> JIT.TargetAddress) {
+//     self.block = block
+//   }
+// }

--- a/Sources/LLVM/PassManager.swift
+++ b/Sources/LLVM/PassManager.swift
@@ -123,8 +123,6 @@ public enum Pass {
   /// This pass eliminates call instructions to the current function which occur
   /// immediately before return instructions.
   case tailCallElimination
-  /// A worklist driven constant propagation pass.
-  case constantPropagation
   /// This pass is used to demote registers to memory references. It basically
   /// undoes the `.promoteMemoryToRegister` pass to make CFG hacking easier.
   case demoteMemoryToRegister
@@ -203,9 +201,6 @@ public enum Pass {
   /// globals.
   case globalOptimizer
   /// This pass propagates constants from call sites into the bodies of
-  /// functions.
-  case ipConstantPropagation
-  /// This pass propagates constants from call sites into the bodies of
   /// functions, and keeps track of whether basic blocks are executable in the
   /// process.
   case ipscc
@@ -213,7 +208,7 @@ public enum Pass {
   /// if the callee can *not* unwind the stack.
   case pruneEH
   /// This transformation attempts to discovery `alloca` allocations of aggregates that can be
-  /// broken down into component scalar values.  
+  /// broken down into component scalar values.
   case scalarReplacementOfAggregates
   /// This pass removes any function declarations (prototypes) that are not used.
   case stripDeadPrototypes

--- a/Sources/LLVM/PassPipeliner.swift
+++ b/Sources/LLVM/PassPipeliner.swift
@@ -306,8 +306,6 @@ extension PassPipeliner {
       LLVMAddSCCPPass(passManager)
     case .tailCallElimination:
       LLVMAddTailCallEliminationPass(passManager)
-    case .constantPropagation:
-      LLVMAddConstantPropagationPass(passManager)
     case .demoteMemoryToRegister:
       LLVMAddDemoteMemoryToRegisterPass(passManager)
     case .verifier:
@@ -344,8 +342,6 @@ extension PassPipeliner {
       LLVMAddGlobalDCEPass(passManager)
     case .globalOptimizer:
       LLVMAddGlobalOptimizerPass(passManager)
-    case .ipConstantPropagation:
-      LLVMAddIPConstantPropagationPass(passManager)
     case .ipscc:
       LLVMAddIPSCCPPass(passManager)
     case .pruneEH:

--- a/Sources/cllvm/shim.h
+++ b/Sources/cllvm/shim.h
@@ -15,10 +15,9 @@
 #include <llvm-c/Initialization.h>
 #include <llvm-c/IRReader.h>
 #include <llvm-c/Linker.h>
-#include <llvm-c/LinkTimeOptimizer.h>
 #include <llvm-c/lto.h>
 #include <llvm-c/Object.h>
-#include <llvm-c/OrcBindings.h>
+#include <llvm-c/Orc.h>
 #include <llvm-c/Support.h>
 #include <llvm-c/Target.h>
 #include <llvm-c/TargetMachine.h>

--- a/Sources/cllvm/shim.h
+++ b/Sources/cllvm/shim.h
@@ -17,7 +17,7 @@
 #include <llvm-c/Linker.h>
 #include <llvm-c/lto.h>
 #include <llvm-c/Object.h>
-#include <llvm-c/Orc.h>
+#include <llvm-c/LLJIT.h>
 #include <llvm-c/Support.h>
 #include <llvm-c/Target.h>
 #include <llvm-c/TargetMachine.h>

--- a/Tests/LLVMTests/IRGlobalSpec.swift
+++ b/Tests/LLVMTests/IRGlobalSpec.swift
@@ -43,9 +43,9 @@ class IRGlobalSpec : XCTestCase {
       let comdatLargestSec = module.comdat(named: "test_largest")
       comdatLargestSec.selectionKind = .largest
 
-      // IRCOMDATGLOBAL: $test_no_dupes = comdat noduplicates
-      let comdatNoDupesSec = module.comdat(named: "test_no_dupes")
-      comdatNoDupesSec.selectionKind = .noDuplicates
+      // IRCOMDATGLOBAL: $test_no_deduplicate = comdat nodeduplicate
+      let comdatNoDeduplicateSec = module.comdat(named: "test_no_deduplicate")
+      comdatNoDeduplicateSec.selectionKind = .noDeduplicate
 
       // IRCOMDATGLOBAL: $test_same_size = comdat samesize
       let comdatSameSizeSec = module.comdat(named: "test_same_size")
@@ -65,9 +65,9 @@ class IRGlobalSpec : XCTestCase {
       var comdatGlobalLargest = builder.addGlobal("comdat_global_largest", initializer: i)
       comdatGlobalLargest.comdat = comdatLargestSec
 
-      // IRCOMDATGLOBAL: @comdat_global_no_dupes = global i8 42, comdat($test_no_dupes)
-      var comdatGlobalNoDupes = builder.addGlobal("comdat_global_no_dupes", initializer: i)
-      comdatGlobalNoDupes.comdat = comdatNoDupesSec
+      // IRCOMDATGLOBAL: @comdat_global_no_deduplicate = global i8 42, comdat($test_no_deduplicate)
+      var comdatGlobalNoDuduplicate = builder.addGlobal("comdat_global_no_deduplicate", initializer: i)
+      comdatGlobalNoDuduplicate.comdat = comdatNoDeduplicateSec
 
       // IRCOMDATGLOBAL: @comdat_global_same_size = global i8 42, comdat($test_same_size)
       var comdatGlobalSameSize = builder.addGlobal("comdat_global_same_size", initializer: i)

--- a/Tests/LLVMTests/IRIntrinsicSpec.swift
+++ b/Tests/LLVMTests/IRIntrinsicSpec.swift
@@ -52,13 +52,13 @@ class IRIntrinsicSpec : XCTestCase {
       // IRINTRINSIC-NEXT: }
       module.dump()
 
-      // IRINTRINSIC: ; Function Attrs: nounwind
+      // IRINTRINSIC: ; Function Attrs: nofree nosync nounwind willreturn
       // IRINTRINSIC-NEXT: declare void @llvm.va_start(i8* %0) #0
 
-      // IRINTRINSIC: ; Function Attrs: nounwind
+      // IRINTRINSIC: ; Function Attrs: nofree nosync nounwind willreturn
       // IRINTRINSIC-NEXT: declare void @llvm.va_copy(i8* %0, i8* %1) #0
 
-      // IRINTRINSIC: ; Function Attrs: nounwind
+      // IRINTRINSIC: ; Function Attrs: nofree nosync nounwind willreturn
       // IRINTRINSIC-NEXT: declare void @llvm.va_end(i8* %0) #0
     })
 
@@ -92,7 +92,7 @@ class IRIntrinsicSpec : XCTestCase {
       // VIRTUALOVERLOAD-IRINTRINSIC-NEXT:  }
       module.dump()
 
-      // VIRTUALOVERLOAD-IRINTRINSIC: ; Function Attrs: nounwind readnone
+      // VIRTUALOVERLOAD-IRINTRINSIC: ; Function Attrs: nofree nosync nounwind readnone willreturn
       // VIRTUALOVERLOAD-IRINTRINSIC-NEXT: declare i32* @llvm.ssa.copy.p0i32(i32* returned %0) #0
     })
 

--- a/Tests/LLVMTests/IRPassManagerSpec.swift
+++ b/Tests/LLVMTests/IRPassManagerSpec.swift
@@ -147,7 +147,7 @@ class IRPassManagerSpec : XCTestCase {
       // CHECK-EXECUTE-STDOPT: ; ModuleID = 'Test'
       // CHECK-EXECUTE-STDOPT: source_filename = "Test"
 
-      // CHECK-EXECUTE-STDOPT: ; Function Attrs: norecurse nounwind readnone
+      // CHECK-EXECUTE-STDOPT: ; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone willreturn
       // CHECK-EXECUTE-STDOPT: define i32 @fun(i32 %0, i32 %1) local_unnamed_addr #0 {
       // CHECK-EXECUTE-STDOPT:   entry:
       // CHECK-EXECUTE-STDOPT:   %2 = icmp eq i32 %0, 1


### PR DESCRIPTION
Apparently the JIT API has changed completely, I haven't fixed it here yet. Also, a few tests are broken for some IR attributes.