### PR TITLE
Fix wrong type sizes in DIBuilder

### DIFF
--- a/Sources/LLVM/DIBuilder.swift
+++ b/Sources/LLVM/DIBuilder.swift
@@ -400,7 +400,7 @@ extension DIBuilder {
       self.llvm, scope.asMetadata(),
       name, name.count, file.asMetadata(), UInt32(line),
       type.asMetadata(), alwaysPreserve.llvm,
-      flags.llvm, alignment.valueInBits)
+      flags.llvm, alignment.valueInBits())
     else {
       fatalError("Failed to allocate metadata for a local variable")
     }
@@ -516,7 +516,7 @@ extension DIBuilder {
       guard let ty = LLVMDIBuilderCreateEnumerationType(
         self.llvm, scope.asMetadata(),
         name, name.count, file.asMetadata(), UInt32(line),
-        size.valueInBits(), alignment.valueInBits,
+        size.valueInBits(), alignment.valueInBits(),
         buf.baseAddress!, UInt32(buf.count),
         underlyingType.asMetadata())
       else {
@@ -551,7 +551,7 @@ extension DIBuilder {
       guard let ty = LLVMDIBuilderCreateUnionType(
         self.llvm, scope.asMetadata(),
         name, name.count, file.asMetadata(), UInt32(line),
-        size.valueInBits(), alignment.valueInBits,
+        size.valueInBits(), alignment.valueInBits(),
         flags.llvm, buf.baseAddress!, UInt32(buf.count),
         UInt32(runtimeVersion), uniqueID, uniqueID.count)
       else {
@@ -580,7 +580,7 @@ extension DIBuilder {
     }
     return diSubs.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateArrayType(
-        self.llvm, size.rawValue, alignment.valueInBits,
+        self.llvm, size.rawValue, alignment.valueInBits(),
         elementType.asMetadata(),
         buf.baseAddress!, UInt32(buf.count))
       else {
@@ -609,7 +609,7 @@ extension DIBuilder {
     }
     return diSubs.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateVectorType(
-        self.llvm, size.rawValue, alignment.valueInBits,
+        self.llvm, size.rawValue, alignment.valueInBits(),
         elementType.asMetadata(),
         buf.baseAddress!, UInt32(buf.count))
       else {
@@ -674,7 +674,7 @@ extension DIBuilder {
   ) -> DIType {
     guard let ty = LLVMDIBuilderCreatePointerType(
       self.llvm, pointee.asMetadata(),
-      size.valueInBits(), alignment.valueInBits,
+      size.valueInBits(), alignment.valueInBits(),
       UInt32(addressSpace.rawValue), name, name.count)
     else {
       fatalError("Failed to allocate metadata")
@@ -708,7 +708,7 @@ extension DIBuilder {
       guard let ty = LLVMDIBuilderCreateStructType(
         self.llvm, scope.asMetadata(), name, name.count,
         file.asMetadata(), UInt32(line),
-        size.valueInBits(), alignment.valueInBits,
+        size.valueInBits(), alignment.valueInBits(),
         flags.llvm,
         baseType?.asMetadata(),
         buf.baseAddress!, UInt32(buf.count), UInt32(runtimeVersion),
@@ -740,7 +740,7 @@ extension DIBuilder {
     guard let ty = LLVMDIBuilderCreateMemberType(
       self.llvm, scope.asMetadata(), name, name.count, file.asMetadata(),
       UInt32(line),
-      size.valueInBits(), alignment.valueInBits,
+      size.valueInBits(), alignment.valueInBits(),
       offset.rawValue,
       flags.llvm, parentType.asMetadata())
     else {
@@ -769,7 +769,7 @@ extension DIBuilder {
       self.llvm, scope.asMetadata(), name, name.count,
       file.asMetadata(), UInt32(line),
       parentType.asMetadata(), flags.llvm,
-      initialValue?.asLLVM(), alignment.valueInBits)
+      initialValue?.asLLVM(), alignment.valueInBits())
     else {
       fatalError("Failed to allocate metadata")
     }
@@ -791,7 +791,7 @@ extension DIBuilder {
   ) -> DIType {
     guard let ty = LLVMDIBuilderCreateMemberPointerType(
       self.llvm, pointee.asMetadata(), baseType.asMetadata(),
-      size.valueInBits(), alignment.valueInBits,
+      size.valueInBits(), alignment.valueInBits(),
       flags.llvm)
     else {
       fatalError("Failed to allocate metadata")
@@ -872,7 +872,7 @@ extension DIBuilder {
     guard let ty = LLVMDIBuilderCreateTypedef(
       self.llvm, type.asMetadata(), name, name.count,
       file.asMetadata(), UInt32(line), scope.asMetadata(),
-      alignment.valueInBits)
+      alignment.valueInBits())
     else {
       fatalError("Failed to allocate metadata")
     }
@@ -927,7 +927,7 @@ extension DIBuilder {
       self.llvm, tag.rawValue, name, name.count,
       scope.asMetadata(), file.asMetadata(), UInt32(line),
       UInt32(runtimeLanguage),
-      size.valueInBits(), alignment.valueInBits,
+      size.valueInBits(), alignment.valueInBits(),
       uniqueID, uniqueID.count) else {
       fatalError("Failed to allocate metadata")
     }
@@ -958,7 +958,7 @@ extension DIBuilder {
       self.llvm, tag.rawValue, name, name.count,
       scope.asMetadata(), file.asMetadata(), UInt32(line),
       UInt32(runtimeVersion),
-      size.valueInBits(), alignment.valueInBits,
+      size.valueInBits(), alignment.valueInBits(),
       flags.llvm,
       uniqueID, uniqueID.count)
     else {
@@ -1024,7 +1024,7 @@ extension DIBuilder {
       guard let ty = LLVMDIBuilderCreateClassType(
         self.llvm, scope.asMetadata(), name, name.count,
         file.asMetadata(), UInt32(line),
-        size.valueInBits(), alignment.valueInBits,
+        size.valueInBits(), alignment.valueInBits(),
         offset.rawValue, flags.llvm,
         baseType?.asMetadata(),
         buf.baseAddress!, UInt32(buf.count),
@@ -1158,7 +1158,7 @@ extension DIBuilder {
   ) -> DIType {
     guard let ty = LLVMDIBuilderCreateObjCIVar(
       self.llvm, name, name.count, file.asMetadata(), UInt32(line),
-      size.valueInBits(), alignment.valueInBits,
+      size.valueInBits(), alignment.valueInBits(),
       offset.rawValue, flags.llvm, type.asMetadata(), property.asMetadata())
     else {
       fatalError("Failed to allocate metadata")
@@ -1257,7 +1257,7 @@ extension DIBuilder {
       type.asMetadata(),
       isLocal.llvm,
       expression?.asMetadata(), declaration?.asMetadata(),
-      alignment.valueInBits)
+      alignment.valueInBits())
     else {
       fatalError("Failed to allocate metadata")
     }

--- a/Sources/LLVM/DIBuilder.swift
+++ b/Sources/LLVM/DIBuilder.swift
@@ -396,12 +396,11 @@ extension DIBuilder {
     type: DIType, alwaysPreserve: Bool = false,
     flags: DIFlags = [], alignment: Alignment
   ) -> LocalVariableMetadata {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let variable = LLVMDIBuilderCreateAutoVariable(
       self.llvm, scope.asMetadata(),
       name, name.count, file.asMetadata(), UInt32(line),
       type.asMetadata(), alwaysPreserve.llvm,
-      flags.llvm, alignment.rawValue * radix)
+      flags.llvm, alignment.valueInBits)
     else {
       fatalError("Failed to allocate metadata for a local variable")
     }
@@ -512,13 +511,12 @@ extension DIBuilder {
     size: Size, alignment: Alignment,
     elements: [DIType], underlyingType: DIType
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     var diTypes = elements.map { $0.asMetadata() as Optional }
     return diTypes.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateEnumerationType(
         self.llvm, scope.asMetadata(),
         name, name.count, file.asMetadata(), UInt32(line),
-        size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+        size.valueInBits(), alignment.valueInBits,
         buf.baseAddress!, UInt32(buf.count),
         underlyingType.asMetadata())
       else {
@@ -548,13 +546,12 @@ extension DIBuilder {
     elements: [DIType],
     runtimeVersion: Int = 0, uniqueID: String = ""
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     var diTypes = elements.map { $0.asMetadata() as Optional }
     return diTypes.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateUnionType(
         self.llvm, scope.asMetadata(),
         name, name.count, file.asMetadata(), UInt32(line),
-        size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+        size.valueInBits(), alignment.valueInBits,
         flags.llvm, buf.baseAddress!, UInt32(buf.count),
         UInt32(runtimeVersion), uniqueID, uniqueID.count)
       else {
@@ -577,14 +574,13 @@ extension DIBuilder {
     size: Size, alignment: Alignment,
     subscripts: [Range<Int>] = []
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     var diSubs = subscripts.map {
       LLVMDIBuilderGetOrCreateSubrange(self.llvm,
                                        Int64($0.lowerBound), Int64($0.count))
     }
     return diSubs.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateArrayType(
-        self.llvm, size.rawValue, alignment.rawValue * radix,
+        self.llvm, size.rawValue, alignment.valueInBits,
         elementType.asMetadata(),
         buf.baseAddress!, UInt32(buf.count))
       else {
@@ -607,14 +603,13 @@ extension DIBuilder {
     size: Size, alignment: Alignment,
     subscripts: [Range<Int>] = []
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     var diSubs = subscripts.map {
       LLVMDIBuilderGetOrCreateSubrange(self.llvm,
                                        Int64($0.lowerBound), Int64($0.count))
     }
     return diSubs.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateVectorType(
-        self.llvm, size.rawValue, alignment.rawValue * radix,
+        self.llvm, size.rawValue, alignment.valueInBits,
         elementType.asMetadata(),
         buf.baseAddress!, UInt32(buf.count))
       else {
@@ -656,10 +651,9 @@ extension DIBuilder {
   public func buildBasicType(
     named name: String, encoding: DIAttributeTypeEncoding, flags: DIFlags, size: Size
   ) -> DIType {
-    let radix = UInt64(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateBasicType(
       self.llvm, name, name.count,
-      size.valueInBits(radix: radix), encoding.llvm, flags.llvm)
+      size.valueInBits(), encoding.llvm, flags.llvm)
     else {
       fatalError("Failed to allocate metadata")
     }
@@ -678,10 +672,9 @@ extension DIBuilder {
     pointee: DIType, size: Size, alignment: Alignment,
     addressSpace: AddressSpace = .zero, name: String = ""
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreatePointerType(
       self.llvm, pointee.asMetadata(),
-      size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+      size.valueInBits(), alignment.valueInBits,
       UInt32(addressSpace.rawValue), name, name.count)
     else {
       fatalError("Failed to allocate metadata")
@@ -710,13 +703,12 @@ extension DIBuilder {
     baseType: DIType? = nil, elements: [DIType] = [],
     vtableHolder: DIType? = nil, runtimeVersion: Int = 0, uniqueID: String = ""
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     var diEls = elements.map { $0.asMetadata() as Optional }
     return diEls.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateStructType(
         self.llvm, scope.asMetadata(), name, name.count,
         file.asMetadata(), UInt32(line),
-        size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+        size.valueInBits(), alignment.valueInBits,
         flags.llvm,
         baseType?.asMetadata(),
         buf.baseAddress!, UInt32(buf.count), UInt32(runtimeVersion),
@@ -745,11 +737,10 @@ extension DIBuilder {
     file: FileMetadata, line: Int,
     size: Size, alignment: Alignment, offset: Size, flags: DIFlags = []
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateMemberType(
       self.llvm, scope.asMetadata(), name, name.count, file.asMetadata(),
       UInt32(line),
-      size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+      size.valueInBits(), alignment.valueInBits,
       offset.rawValue,
       flags.llvm, parentType.asMetadata())
     else {
@@ -774,12 +765,11 @@ extension DIBuilder {
     line: Int, alignment: Alignment, flags: DIFlags = [],
     initialValue: IRConstant? = nil
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateStaticMemberType(
       self.llvm, scope.asMetadata(), name, name.count,
       file.asMetadata(), UInt32(line),
       parentType.asMetadata(), flags.llvm,
-      initialValue?.asLLVM(), alignment.rawValue * radix)
+      initialValue?.asLLVM(), alignment.valueInBits)
     else {
       fatalError("Failed to allocate metadata")
     }
@@ -799,10 +789,9 @@ extension DIBuilder {
     size: Size, alignment: Alignment,
     flags: DIFlags = []
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateMemberPointerType(
       self.llvm, pointee.asMetadata(), baseType.asMetadata(),
-      size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+      size.valueInBits(), alignment.valueInBits,
       flags.llvm)
     else {
       fatalError("Failed to allocate metadata")
@@ -880,11 +869,10 @@ extension DIBuilder {
     file: FileMetadata,
     line: Int
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateTypedef(
       self.llvm, type.asMetadata(), name, name.count,
       file.asMetadata(), UInt32(line), scope.asMetadata(),
-      alignment.rawValue * radix)
+      alignment.valueInBits)
     else {
       fatalError("Failed to allocate metadata")
     }
@@ -904,12 +892,11 @@ extension DIBuilder {
     of derived: DIType, to base: DIType,
     baseOffset: Size, virtualBasePointerOffset: Size, flags: DIFlags = []
   ) -> DIType {
-    let radix = UInt64(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateInheritance(
       self.llvm, derived.asMetadata(),
       base.asMetadata(),
-      baseOffset.valueInBits(radix: radix),
-      UInt32(virtualBasePointerOffset.valueInBits(radix: radix)),
+      baseOffset.valueInBits(),
+      UInt32(virtualBasePointerOffset.valueInBits()),
       flags.llvm)
     else {
       fatalError("Failed to allocate metadata")
@@ -936,12 +923,11 @@ extension DIBuilder {
     size: Size, alignment: Alignment,
     runtimeLanguage: Int = 0, uniqueID: String = ""
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateForwardDecl(
       self.llvm, tag.rawValue, name, name.count,
       scope.asMetadata(), file.asMetadata(), UInt32(line),
       UInt32(runtimeLanguage),
-      size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+      size.valueInBits(), alignment.valueInBits,
       uniqueID, uniqueID.count) else {
       fatalError("Failed to allocate metadata")
     }
@@ -968,12 +954,11 @@ extension DIBuilder {
     size: Size, alignment: Alignment, flags: DIFlags = [],
     runtimeVersion: Int = 0, uniqueID: String = ""
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateReplaceableCompositeType(
       self.llvm, tag.rawValue, name, name.count,
       scope.asMetadata(), file.asMetadata(), UInt32(line),
       UInt32(runtimeVersion),
-      size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+      size.valueInBits(), alignment.valueInBits,
       flags.llvm,
       uniqueID, uniqueID.count)
     else {
@@ -1000,12 +985,11 @@ extension DIBuilder {
     size: Size, offset: Size, storageOffset: Size,
     flags: DIFlags = []
   ) -> DIType {
-    let radix = UInt64(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateBitFieldMemberType(
       self.llvm, scope.asMetadata(), name, name.count,
       file.asMetadata(), UInt32(line),
-      size.valueInBits(radix: radix), offset.valueInBits(radix: radix),
-      storageOffset.valueInBits(radix: radix),
+      size.valueInBits(), offset.valueInBits(),
+      storageOffset.valueInBits(),
       flags.llvm, type.asMetadata())
     else {
       fatalError("Failed to allocate metadata")
@@ -1035,13 +1019,12 @@ extension DIBuilder {
     elements: [DIType] = [],
     vtableHolder: DIType? = nil, uniqueID: String = ""
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     var diEls = elements.map { $0.asMetadata() as Optional }
     return diEls.withUnsafeMutableBufferPointer { buf in
       guard let ty = LLVMDIBuilderCreateClassType(
         self.llvm, scope.asMetadata(), name, name.count,
         file.asMetadata(), UInt32(line),
-        size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+        size.valueInBits(), alignment.valueInBits,
         offset.rawValue, flags.llvm,
         baseType?.asMetadata(),
         buf.baseAddress!, UInt32(buf.count),
@@ -1173,10 +1156,9 @@ extension DIBuilder {
     file: FileMetadata, line: Int,
     size: Size, alignment: Alignment, offset: Size, flags: DIFlags = []
   ) -> DIType {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateObjCIVar(
       self.llvm, name, name.count, file.asMetadata(), UInt32(line),
-      size.valueInBits(radix: UInt64(radix)), alignment.rawValue * radix,
+      size.valueInBits(), alignment.valueInBits,
       offset.rawValue, flags.llvm, type.asMetadata(), property.asMetadata())
     else {
       fatalError("Failed to allocate metadata")
@@ -1268,7 +1250,6 @@ extension DIBuilder {
     declaration: IRMetadata? = nil,
     alignment: Alignment
   ) -> ExpressionMetadata {
-    let radix = UInt32(self.module.dataLayout.intPointerType().width)
     guard let ty = LLVMDIBuilderCreateGlobalVariableExpression(
       self.llvm, scope.asMetadata(),
       name, name.count, linkageName, linkageName.count,
@@ -1276,7 +1257,7 @@ extension DIBuilder {
       type.asMetadata(),
       isLocal.llvm,
       expression?.asMetadata(), declaration?.asMetadata(),
-      alignment.rawValue * radix)
+      alignment.valueInBits)
     else {
       fatalError("Failed to allocate metadata")
     }

--- a/Sources/LLVM/Units.swift
+++ b/Sources/LLVM/Units.swift
@@ -22,6 +22,11 @@ public struct Alignment: Comparable, Hashable {
   public var isZero: Bool {
     return self.rawValue == 0
   }
+    
+  /// Returns this alignment value in bits
+  public var valueInBits: UInt32 {
+    return self.rawValue * 8
+  }
 
   /// Returns the log-base-two value of this alignment as a 32-bit integer.
   ///

--- a/Sources/LLVM/Units.swift
+++ b/Sources/LLVM/Units.swift
@@ -22,10 +22,13 @@ public struct Alignment: Comparable, Hashable {
   public var isZero: Bool {
     return self.rawValue == 0
   }
-    
-  /// Returns this alignment value in bits
-  public var valueInBits: UInt32 {
-    return self.rawValue * 8
+
+  /// Returns the value of this alignment in bits according to a given radix.
+  ///
+  /// - parameter radix: The radix value. Defaults to 8 bits per alignment unit.
+  /// - returns: A value in bits.
+  public func valueInBits(radix: UInt32 = 8) -> UInt32 {
+    return self.rawValue * radix
   }
 
   /// Returns the log-base-two value of this alignment as a 32-bit integer.

--- a/Tests/LLVMTests/DIBuilderSpec.swift
+++ b/Tests/LLVMTests/DIBuilderSpec.swift
@@ -39,11 +39,11 @@ class DIBuilderSpec : XCTestCase {
 
       let global = builder.addGlobal("global", type: IntType.int32)
       global.initializer = IntType.int32.constant(5)
-      let globalTy = debugBuilder.buildBasicType(named: "int32_t", encoding: .signed, flags: [], size: Size(8))
+      let globalTy = debugBuilder.buildBasicType(named: "int32_t", encoding: .signed, flags: [], size: Size(bits: 32))
 
       // DIEXPRESSION: !{{[0-9]+}} = !DIGlobalVariableExpression(var: !{{[0-9]+}}, expr: !DIExpression())
       // DIEXPRESSION: !{{[0-9]+}} = distinct !DIGlobalVariable(name: "global", linkageName: "global", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: 42, type: !{{[0-9]+}}, isLocal: true, isDefinition: true)
-      // DIEXPRESSION: !{{[0-9]+}} = !DIBasicType(name: "int32_t", size: 512, encoding: DW_ATE_signed)
+      // DIEXPRESSION: !{{[0-9]+}} = !DIBasicType(name: "int32_t", size: 32, encoding: DW_ATE_signed)
       // DIEXPRESSION: !{{[0-9]+}} = !DIGlobalVariableExpression(var: !{{[0-9]+}}, expr: !{{[0-9]+}})
       let expr = debugBuilder.buildGlobalExpression(
         named: "global", linkageName: "global", type: globalTy,


### PR DESCRIPTION
I don't understand why `radix` was used in DIBuilder. One byte is always 8 bits, and LLVM already assumes that, so there is no point in making it variable.
And there definitely isn't 64 bits in a byte (the width of an intptr). This means the width of types was 8 times larger than they should be: an int32_t was considered 256 bits instead of 32 bits (cf the unit tests, where its size was also erroneously set to 8 bytes).

Fixes #239 